### PR TITLE
Document cloning from public URL rather than ssh

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -20,7 +20,7 @@ by using ``git``:
 
 .. code:: bash
 
-    $ git clone github.com:danielquinn/paperless.git
+    $ git clone https://github.com/danielquinn/paperless.git
     $ cd paperless
 
 or just download the tarball and go that route:


### PR DESCRIPTION
Trivial docs change to point to public https URL on github.