### PR TITLE
Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:14.04
+
+RUN mkdir -p /opt/paperless/scripts
+WORKDIR /opt/paperless
+
+COPY scripts/vagrant-provision /opt/paperless/scripts/
+COPY requirements.txt /opt/paperless/
+
+RUN bash /opt/paperless/scripts/vagrant-provision
+
+ADD . /opt/paperless/
+
+WORKDIR /opt/paperless/src/
+
+ENV PYTHONPATH /usr/local/lib/python3.4/dist-packages/:/usr/local/lib/python2.7/dist-packages/:/usr/lib/python3/dist-packages/
+ENV PAPERLESS_PASSPHRASE some-secret-string
+
+RUN python manage.py migrate
+
+EXPOSE 8000
+
+CMD python manage.py runserver 0.0.0.0:8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,14 @@ WORKDIR /opt/paperless/src/
 
 ENV PYTHONPATH /usr/local/lib/python3.4/dist-packages/:/usr/local/lib/python2.7/dist-packages/:/usr/lib/python3/dist-packages/
 ENV PAPERLESS_PASSPHRASE some-secret-string
+ENV CONSUMPTION_DIR /opt/consumption
+
+ENV USERNAME admin
+ENV EMAIL admin@example.com
+ENV PASSWORD paperless
 
 RUN python manage.py migrate
 
 EXPOSE 8000
 
-CMD python manage.py runserver 0.0.0.0:8000
+CMD echo "from django.contrib.auth.models import User; import os; User.objects.create_superuser(os.environ.get('USERNAME'), os.environ.get('EMAIL'), os.environ.get('PASSWORD'))" | python manage.py shell && python manage.py runserver 0.0.0.0:8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,12 @@ FROM ubuntu:14.04
 RUN mkdir -p /opt/paperless/scripts
 WORKDIR /opt/paperless
 
+RUN apt-get install -y tofrodos
+
 COPY scripts/vagrant-provision /opt/paperless/scripts/
 COPY requirements.txt /opt/paperless/
 
+RUN fromdos /opt/paperless/scripts/vagrant-provision
 RUN bash /opt/paperless/scripts/vagrant-provision
 
 ADD . /opt/paperless/

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -112,6 +112,24 @@ Vagrant Method
 .. _Vagrant: https://vagrantup.com/
 .. _Paperless server: http://172.28.128.4:8000
 
+.. _setup-installation-docker:
+
+Docker Method
+.............
+
+1. Install `Docker`_.
+2. Run ``docker build -t paperless .``. Get a cup of coffee as the image builds for the first time.
+3. Run ``docker run -d -p 8000:8000 paperless`` then navigate to https://localhost:8000
+
+The Docker image supports the following environment variables. These variables can be passed into the ``docker run`` command above with the ``-e MY_VAR my_value`` flag.
+
+- PAPERLESS_PASSPHRASE (default: some-secret-string)
+- CONSUMPTION_DIR (default: /opt/consumption)
+- USERNAME (default: admin)
+- EMAIL (default: admin@example.com)
+- PASSWORD (default: paperless)
+
+.. _Docker: https://www.docker.com/
 
 .. _making-things-a-little-more-permanent:
 


### PR DESCRIPTION
**NOTE:** Currently a work in progress, the **document_consumer** is not running and the appropriate Docker volumes have not been added.

Ref #2.

@danielquinn: I'm getting the following error from the PIL module when trying to run `python manage.py document_consumer`:

```
  ...
  File "/usr/local/lib/python3.4/dist-packages/PIL/Image.py", line 66, in <module>
    from PIL import _imaging as core
ImportError: cannot import name _imaging
```

Does that look familiar or do you have anything else I could try? I had to mess around with the PYTHONPATH because Docker wasn't picking up the default folders.