### PR TITLE
Fix matching if user supplied an empty value

### DIFF
--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -86,6 +86,9 @@ class Tag(SluggedModel):
             self.name, self.match, self.get_matching_algorithm_display())
 
     def matches(self, text):
+        # Check that match is not empty
+        if self.match.strip() == "":
+            return False
 
         if self.matching_algorithm == self.MATCH_ALL:
             for word in self.match.split(" "):


### PR DESCRIPTION
In my tests, every single tag that had no value set for "match" was automatically applied to every new document, probably because of the change in fc5d89c.

I don't know if this is how it is supposed to work now, but I would like to be able to have tags not matching anything. This change checks if the user supplied an empty value and if so doesn't match the tag.