### PR TITLE
Enabling django-suit theme

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Django==1.9
 django-extensions==1.6.1
+django-suit==0.2.16
 filemagic==1.6
 langdetect==1.0.5
 Pillow==3.0.0

--- a/src/manage.py
+++ b/src/manage.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+from django.conf.global_settings import TEMPLATE_CONTEXT_PROCESSORS as TCP
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "paperless.settings")

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 """
 
 import os
+from django.conf.global_settings import TEMPLATE_CONTEXT_PROCESSORS as TCP
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -31,7 +32,8 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
-
+    'suit',
+    
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -74,6 +76,8 @@ TEMPLATES = [
         },
     },
 ]
+
+TEMPLATE_CONTEXT_PROCESSORS = TCP + ['django.core.context_processors.request']
 
 WSGI_APPLICATION = 'paperless.wsgi.application'
 


### PR DESCRIPTION
Please feel free to reject this if it is unwelcome. As I've been playing around trying to learn Django a little bit, I stumbled upon `django-suit`, which provides an easy way to switch to a more modern looking admin interface. I enabled it locally and it doesn't seem to have had any negative impacts, and seems to be more responsive in terms of navigating around the database.

Feel free to checkout my branch to test it out!

Main interface screen:
![image](https://cloud.githubusercontent.com/assets/1278301/13060631/da4751d0-d400-11e5-9ad1-8948e5e40924.png)

Documents page:
![image](https://cloud.githubusercontent.com/assets/1278301/13060661/12fe604a-d401-11e5-9ca5-4794379a35b1.png)
