### PR TITLE
Compensate for case and format of jpg vs. jpeg

### DIFF
--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -264,6 +264,12 @@ class Consumer(object):
                     Tag.objects.get_or_create(slug=t, defaults={"name": t})[0])
             return tuple(r)
 
+        def get_suffix(suffix):
+            suffix = suffix.lower()
+            if suffix == "jpeg":
+                return "jpg"
+            return suffix
+
         # First attempt: "<sender> - <title> - <tags>.<suffix>"
         m = re.match(self.REGEX_SENDER_TITLE_TAGS, parseable)
         if m:
@@ -271,17 +277,22 @@ class Consumer(object):
                 get_sender(m.group(1)),
                 m.group(2),
                 get_tags(m.group(3)),
-                m.group(4)
+                get_suffix(m.group(4))
             )
 
         # Second attempt: "<sender> - <title>.<suffix>"
         m = re.match(self.REGEX_SENDER_TITLE, parseable)
         if m:
-            return get_sender(m.group(1)), m.group(2), (), m.group(3)
+            return (
+                get_sender(m.group(1)),
+                m.group(2),
+                (),
+                get_suffix(m.group(3))
+            )
 
         # That didn't work, so we assume sender and tags are None
         m = re.match(self.REGEX_TITLE, parseable)
-        return None, m.group(1), (), m.group(2)
+        return None, m.group(1), (), get_suffix(m.group(2))
 
     def _store(self, text, doc):
 

--- a/src/documents/tests/test_consumer.py
+++ b/src/documents/tests/test_consumer.py
@@ -7,15 +7,23 @@ class TestAttachment(TestCase):
 
     TAGS = ("tag1", "tag2", "tag3")
     CONSUMER = Consumer()
+    SUFFIXES = (
+        "pdf", "png", "jpg", "jpeg", "gif",
+        "PDF", "PNG", "JPG", "JPEG", "GIF",
+        "PdF", "PnG", "JpG", "JPeG", "GiF",
+    )
 
     def _test_guess_attributes_from_name(self, path, sender, title, tags):
-        for suffix in ("pdf", "png", "jpg", "jpeg", "gif"):
+        for suffix in self.SUFFIXES:
             f = path.format(suffix)
             results = self.CONSUMER._guess_attributes_from_name(f)
             self.assertEqual(results[0].name, sender, f)
             self.assertEqual(results[1], title, f)
             self.assertEqual(tuple([t.slug for t in results[2]]), tags, f)
-            self.assertEqual(results[3], suffix, f)
+            if suffix.lower() == "jpeg":
+                self.assertEqual(results[3], "jpg", f)
+            else:
+                self.assertEqual(results[3], suffix.lower(), f)
 
     def test_guess_attributes_from_name0(self):
         self._test_guess_attributes_from_name(

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -13,7 +13,7 @@ from .models import Sender, Tag, Document
 from .serialisers import SenderSerializer, TagSerializer, DocumentSerializer
 
 
-class PdfView(DetailView):
+class FetchView(DetailView):
 
     model = Document
 

--- a/src/paperless/urls.py
+++ b/src/paperless/urls.py
@@ -21,7 +21,7 @@ from django.contrib import admin
 from rest_framework.routers import DefaultRouter
 
 from documents.views import (
-    PdfView, PushView, SenderViewSet, TagViewSet, DocumentViewSet)
+    FetchView, PushView, SenderViewSet, TagViewSet, DocumentViewSet)
 
 router = DefaultRouter()
 router.register(r'senders', SenderViewSet)
@@ -38,7 +38,7 @@ urlpatterns = [
     url(r"^api/", include(router.urls, namespace="drf")),
 
     # File downloads
-    url(r"^fetch/(?P<pk>\d+)$", PdfView.as_view(), name="fetch"),
+    url(r"^fetch/(?P<pk>\d+)$", FetchView.as_view(), name="fetch"),
 
     # The Django admin
     url(r"", admin.site.urls),


### PR DESCRIPTION
This fixes an ugly bug that occurred when the consumer indexed a jpeg file that was suffixed with either `.jpeg` or even `.JPG`.  The result was that the file was indeed consumed, given an id, encrypted and stored in the media directory, but it was unavailable via the web interface because of naming.

This merge fixes all of that (hopefully), but it doesn't provide a means of getting your mis-named files out of paperless.  For that, you need to do two things:

1. Rename the files in the media directory.  This is pretty simple, and if you have the standard `rename` utility on your system, even easier.  Basically you need to change all files in the media directory that contain `jpeg` to `jpg`:

        $ cd /path/to/media/documents/
        $ rename jpeg jpg *

2. Next, you need to tell the database that the file type has changed.  To do that, you can use the Django shell since that's easiest:

        $ cd /path/to/paperless/src/ (the location of manage.py)
        $ ./manage.py shell
        (now that you're in the Django shell)
        from documents.models import Document
        Document.objects.filter(file_type="jpeg").update(file_type="jpg")

    ...and that's it.  If you're uncomfortable with the Django shell, you can always go with sqlite:

        $ cd /path/to/paperless/src/ (the location of manage.py)
        $ ./manage.py dbshell
        UPDATE documents_document SET file_type = 'jpg' WHERE file_type = 'jpeg';
