### PR TITLE
Add brew install libmagic to apple-tastic requirements.

### DIFF
--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -52,6 +52,7 @@ well as ImageMagick:
 
     $ brew install ghostscript
     $ brew install imagemagick
+    $ brew install libmagic
 
 
 .. _requirements-baremetal:


### PR DESCRIPTION
`./manage.py migrate` ran into `raise ImportError('Unable to find magic library')` on latest Apple tastic.

Perhaps I missed something else.