### PR TITLE
Remove PAPERLESS_OCR_LANGUAGES from docker-compose.yml

### DIFF
--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -11,8 +11,6 @@ services:
             - data:/usr/src/paperless/data
             - media:/usr/src/paperless/media
         env_file: docker-compose.env
-        environment:
-            - PAPERLESS_OCR_LANGUAGES=
         command: ["runserver", "0.0.0.0:8000"]
 
     consumer:


### PR DESCRIPTION
It is defined in `docker-compose.env` already.