### PR TITLE
Don't fail on setting consumption-dir permissions

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -16,8 +16,24 @@ map_uidgid() {
 
 set_permissions() {
     # Set permissions for consumption directory
-    chgrp paperless "$PAPERLESS_CONSUMPTION_DIR"
-    chmod g+x "$PAPERLESS_CONSUMPTION_DIR"
+    chgrp paperless "$PAPERLESS_CONSUMPTION_DIR" || {
+        echo "Changing group of consumption directory:"
+        echo "  $PAPERLESS_CONSUMPTION_DIR"
+        echo "failed."
+        echo ""
+        echo "Either try to set it on your host-mounted directory"
+        echo "directly, or make sure that the directory has \`o+x\`"
+        echo "permissions and the files in it at least \`o+r\`."
+    } >&2
+    chmod g+x "$PAPERLESS_CONSUMPTION_DIR" || {
+        echo "Changing group permissions of consumption directory:"
+        echo "  $PAPERLESS_CONSUMPTION_DIR"
+        echo "failed."
+        echo ""
+        echo "Either try to set it on your host-mounted directory"
+        echo "directly, or make sure that the directory has \`o+x\`"
+        echo "permissions and the files in it at least \`o+r\`."
+    } >&2
 
     # Set permissions for application directory
     chown -Rh paperless:paperless /usr/src/paperless


### PR DESCRIPTION
Changing the group or permissions on the consumption directory can fail, especially on network-mounted directories. If it fails, don't exit the consumer, but rather output a warning on what the user has to do.

This is related to (and should close) issue #102.