### PR TITLE
Update setup flow for bare metal with systemd

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -300,13 +300,19 @@ Standard (Bare Metal, Systemd)
 If you're running on a bare metal system that's using Systemd, you can use the
 service unit files in the ``scripts`` directory to set this up.  You'll need to
 create a user called ``paperless`` and setup Paperless to be in a place that
-this new user can read and write to.  Then, you can just tell Systemd to enable
-the two ``.service`` files::
+this new user can read and write to. Be sure to edit the service scripts to point
+to the proper location of your paperless install. Note that if your system aliased
+``/usr/bin/python`` to python3 you should modify the ``ExecStart`` line to look like
+this: ``ExecStart=/usr/bin/python3 /path/to/paperless/src/manage.py document_consumer``.
+If you don't want to make a new user, you can change the ``Group`` and ``User`` variables
+accordingly.
 
-    # systemctl enable /path/to/paperless/scripts/paperless-consumer.service
-    # systemctl enable /path/to/paperless/scripts/paperless-webserver.service
-    # systemctl start /path/to/paperless/scripts/paperless-consumer.service
-    # systemctl start /path/to/paperless/scripts/paperless-webserver.service
+Then, you can just tell Systemd to enable the two ``.service`` files::
+
+    # sudo systemctl enable /path/to/paperless/scripts/paperless-consumer.service
+    # sudo systemctl enable /path/to/paperless/scripts/paperless-webserver.service
+    # sudo systemctl start paperless-consumer
+    # sudo systemctl start paperless-webserver
 
 
 .. _setup-permanent-standard-ubuntu14:

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -301,18 +301,17 @@ If you're running on a bare metal system that's using Systemd, you can use the
 service unit files in the ``scripts`` directory to set this up.  You'll need to
 create a user called ``paperless`` and setup Paperless to be in a place that
 this new user can read and write to. Be sure to edit the service scripts to point
-to the proper location of your paperless install. Note that if your system aliased
-``/usr/bin/python`` to python3 you should modify the ``ExecStart`` line to look like
-this: ``ExecStart=/usr/bin/python3 /path/to/paperless/src/manage.py document_consumer``.
+to the proper location of your paperless install, referencing the appropriate Python
+binary. For example: ``ExecStart=/path/to/python3 /path/to/paperless/src/manage.py document_consumer``.
 If you don't want to make a new user, you can change the ``Group`` and ``User`` variables
 accordingly.
 
-Then, you can just tell Systemd to enable the two ``.service`` files::
+Then, you can just tell Systemd as ``root`` (or using ``sudo``) to enable the two ``.service`` files::
 
-    # sudo systemctl enable /path/to/paperless/scripts/paperless-consumer.service
-    # sudo systemctl enable /path/to/paperless/scripts/paperless-webserver.service
-    # sudo systemctl start paperless-consumer
-    # sudo systemctl start paperless-webserver
+    # systemctl enable /path/to/paperless/scripts/paperless-consumer.service
+    # systemctl enable /path/to/paperless/scripts/paperless-webserver.service
+    # systemctl start paperless-consumer
+    # systemctl start paperless-webserver
 
 
 .. _setup-permanent-standard-ubuntu14:


### PR DESCRIPTION
The default files assume a specific path on the target system. Added a note letting people know they need to edit the files. Also fixed a bug with enabling the service - it caused odd errors on my system. Tested on Centos 7.