### PR TITLE
add pre-consume hook

### DIFF
--- a/src/documents/apps.py
+++ b/src/documents/apps.py
@@ -8,11 +8,14 @@ class DocumentsConfig(AppConfig):
     def ready(self):
 
         from .signals import document_consumption_finished
+        from .signals import document_consumption_started
         from .signals.handlers import (
-            set_correspondent, set_tags, run_external_script)
+            set_correspondent, set_tags, run_post_consume_external_script, run_pre_consume_external_script)
 
         document_consumption_finished.connect(set_tags)
         document_consumption_finished.connect(set_correspondent)
-        document_consumption_finished.connect(run_external_script)
+        document_consumption_finished.connect(run_post_consume_external_script)
+
+        document_consumption_started.connect(run_pre_consume_external_script)
 
         AppConfig.ready(self)

--- a/src/documents/apps.py
+++ b/src/documents/apps.py
@@ -7,15 +7,16 @@ class DocumentsConfig(AppConfig):
 
     def ready(self):
 
-        from .signals import document_consumption_finished
         from .signals import document_consumption_started
+        from .signals import document_consumption_finished
         from .signals.handlers import (
-            set_correspondent, set_tags, run_post_consume_external_script, run_pre_consume_external_script)
+            set_correspondent, set_tags, run_pre_consume_script,
+            run_post_consume_script)
+
+        document_consumption_started.connect(run_pre_consume_script)
 
         document_consumption_finished.connect(set_tags)
         document_consumption_finished.connect(set_correspondent)
-        document_consumption_finished.connect(run_post_consume_external_script)
-
-        document_consumption_started.connect(run_pre_consume_external_script)
+        document_consumption_finished.connect(run_post_consume_script)
 
         AppConfig.ready(self)

--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -57,7 +57,18 @@ def set_tags(sender, document=None, logging_group=None, **kwargs):
     document.tags.add(*relevant_tags)
 
 
-def run_post_consume_external_script(sender, document, **kwargs):
+def run_pre_consume_script(sender, filename, **kwargs):
+
+    if not settings.PRE_CONSUME_SCRIPT:
+        return
+
+    Popen((
+        settings.PRE_CONSUME_SCRIPT,
+        filename
+    )).wait()
+
+
+def run_post_consume_script(sender, document, **kwargs):
 
     if not settings.POST_CONSUME_SCRIPT:
         return
@@ -73,13 +84,3 @@ def run_post_consume_external_script(sender, document, **kwargs):
         str(document.correspondent),
         str(",".join(document.tags.all().values_list("slug", flat=True)))
     )).wait()
-
-def run_pre_consume_external_script(sender, filename, **kwargs):
-
-    if not settings.PRE_CONSUME_SCRIPT:
-        return
-
-    Popen((
-        settings.PRE_CONSUME_SCRIPT,
-        filename
-)).wait()

--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -57,7 +57,7 @@ def set_tags(sender, document=None, logging_group=None, **kwargs):
     document.tags.add(*relevant_tags)
 
 
-def run_external_script(sender, document, **kwargs):
+def run_post_consume_external_script(sender, document, **kwargs):
 
     if not settings.POST_CONSUME_SCRIPT:
         return
@@ -73,3 +73,13 @@ def run_external_script(sender, document, **kwargs):
         str(document.correspondent),
         str(",".join(document.tags.all().values_list("slug", flat=True)))
     )).wait()
+
+def run_pre_consume_external_script(sender, filename, **kwargs):
+
+    if not settings.PRE_CONSUME_SCRIPT:
+        return
+
+    Popen((
+        settings.PRE_CONSUME_SCRIPT,
+        filename
+)).wait()

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -230,6 +230,7 @@ SHARED_SECRET = os.getenv("PAPERLESS_SHARED_SECRET", "")
 
 # Trigger a script after every successful document consumption?
 POST_CONSUME_SCRIPT = os.getenv("PAPERLESS_POST_CONSUME_SCRIPT")
+PRE_CONSUME_SCRIPT = os.getenv("PAPERLESS_PRE_CONSUME_SCRIPT")
 
 #
 # TODO: Remove after 0.2

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -229,8 +229,8 @@ PASSPHRASE = os.getenv("PAPERLESS_PASSPHRASE")
 SHARED_SECRET = os.getenv("PAPERLESS_SHARED_SECRET", "")
 
 # Trigger a script after every successful document consumption?
-POST_CONSUME_SCRIPT = os.getenv("PAPERLESS_POST_CONSUME_SCRIPT")
 PRE_CONSUME_SCRIPT = os.getenv("PAPERLESS_PRE_CONSUME_SCRIPT")
+POST_CONSUME_SCRIPT = os.getenv("PAPERLESS_POST_CONSUME_SCRIPT")
 
 #
 # TODO: Remove after 0.2


### PR DESCRIPTION
Hi,
my scanner is generating pdfs that cannot be parsed by imagemagick, so I have to run them through pdf2cairo to convert them to pdfs that imagemagick can read.

So I had the need to execute a command before the file would actually be consumed. For that, I added a pre-consume hook in the same way the existing post-consume hook was already in place.

My script looks like this:

```
#!/usr/local/bin/bash

TMPFILE=$(mktemp pdfconvert)

pdftocairo "$1" -pdf "$TMPFILE"
mv "$TMPFILE" "$1"
```

To prevent confusion, I renamed the existing `run_external_script` method to `run_post_consume_external_script`.

I hope this is of use and I didn't butcher your coding style too much. ;)

Regards,
phry
