### PR TITLE
Update setup.rst

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -550,8 +550,7 @@ your gunicorn instance.  This should do the trick:
 Vagrant
 .......
 
-You're currently on your own, but the Ubuntu explanation above may be enough.
-
+You may use the Ubuntu explanation above. Replace ``(local-filesystems and net-device-up IFACE=eth0)`` with ``vagrant-mounted``.
 
 .. _setup-permanent-docker:
 


### PR DESCRIPTION
Added a line on how to use the ubuntu upstart example in Vagrant. It took me hours to figure out why it wouldn't start on boot but would when you would type "start paperless-server" manually. The start on vagrant-mounted solved the problem, so I thought it would be good to share this with the paperless community.