### PR TITLE
Randomize secret key

### DIFF
--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 """
 
 import os
+import uuid
 
 from dotenv import load_dotenv
 
@@ -22,7 +23,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'e11fl1oa-*ytql8p)(06fbj4ukrlo+n7k&q5+$1md7i+mge=ee'
+SECRET_KEY = os.getenv("PAPERLESS_SECRET_KEY") or str(uuid.uuid4())
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
Provide ability to load secret key from environment otherwise use a random uuid. It shouldn't affect older versions. Closes #171