### PR TITLE
Include responsive/mobile UI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ python-dotenv>=0.3.0
 python-gnupg>=0.3.8
 pytz>=2015.7
 gunicorn==19.6.0
+django-flat-responsive==1.2.0
 
 # For the tests
 pytest

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -52,6 +52,7 @@ if _allowed_hosts:
 
 INSTALLED_APPS = [
 
+    'flat_responsive',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',


### PR DESCRIPTION
Hi @danielquinn,
there is a nice small package around, called [django-flat-responsive](https://github.com/elky/django-flat-responsive). Since you decided not to use django-suit for now, this improves the stock django admin experience on mobile browsers. I use it for browsing my documents on the go.

Regards
Enno