### PR TITLE
Add manager command to re-tag documents without correspondent

### DIFF
--- a/src/documents/management/commands/document_correspondents.py
+++ b/src/documents/management/commands/document_correspondents.py
@@ -6,12 +6,11 @@ from ...mixins import Renderable
 
 
 class Command(Renderable, BaseCommand):
-
     help = """
         Using the current set of correspondent rules, apply said rules to all
         documents in the database, effectively allowing you to back-tag all
-        previously indexed documents with correspondent created (or modified) after
-        their initial import.
+        previously indexed documents with correspondent created (or modified)
+        after their initial import.
     """.replace("    ", "")
 
     def __init__(self, *args, **kwargs):
@@ -27,7 +26,8 @@ class Command(Renderable, BaseCommand):
             if document.correspondent:
                 continue
 
-            potential_correspondents = list(Correspondent.match_all(document.content))
+            potential_correspondents = list(
+                Correspondent.match_all(document.content))
             if not potential_correspondents:
                 continue
 
@@ -35,9 +35,11 @@ class Command(Renderable, BaseCommand):
 
             selected = potential_correspondents[0]
             if potential_count > 1:
-                message = "Detected {} potential correspondents for {}, so we've opted for {}"
+                message = "Detected {} potential correspondents for {}, " \
+                          "so we've opted for {}"
                 print(message.format(potential_count, document, selected))
 
-            print('Tagging {} with correspondent "{}"'.format(document, selected))
+            print('Tagging {} with correspondent "{}"'.format(document,
+                                                              selected))
             document.correspondent = selected
             document.save(update_fields=("correspondent",))

--- a/src/documents/management/commands/document_correspondents.py
+++ b/src/documents/management/commands/document_correspondents.py
@@ -1,0 +1,43 @@
+from django.core.management.base import BaseCommand
+
+from documents.models import Document, Correspondent
+
+from ...mixins import Renderable
+
+
+class Command(Renderable, BaseCommand):
+
+    help = """
+        Using the current set of correspondent rules, apply said rules to all
+        documents in the database, effectively allowing you to back-tag all
+        previously indexed documents with correspondent created (or modified) after
+        their initial import.
+    """.replace("    ", "")
+
+    def __init__(self, *args, **kwargs):
+        self.verbosity = 0
+        BaseCommand.__init__(self, *args, **kwargs)
+
+    def handle(self, *args, **options):
+
+        self.verbosity = options["verbosity"]
+
+        for document in Document.objects.all():
+            # No matching correspondents, so no need to continue
+            if document.correspondent:
+                continue
+
+            potential_correspondents = list(Correspondent.match_all(document.content))
+            if not potential_correspondents:
+                continue
+
+            potential_count = len(potential_correspondents)
+
+            selected = potential_correspondents[0]
+            if potential_count > 1:
+                message = "Detected {} potential correspondents for {}, so we've opted for {}"
+                print(message.format(potential_count, document, selected))
+
+            print('Tagging {} with correspondent "{}"'.format(document, selected))
+            document.correspondent = selected
+            document.save(update_fields=("correspondent",))


### PR DESCRIPTION
hello,

Like in #120 I've needed this possibility so I've created a "document_correspondents" manager command like the one for tags.
I does ignore if a correspondent is already associated to a document.
I've based the re-tagger command for correspondent on the code from the signal/handler. 

I tried it with a (small) set of files with either regexp or litteral and it does seems to work as intended.