### PR TITLE
Be able to override static root using config file

### DIFF
--- a/paperless.conf.example
+++ b/paperless.conf.example
@@ -88,6 +88,10 @@ PAPERLESS_SHARED_SECRET=""
 # Override the default MEDIA_ROOT here.  This is where all files are stored.
 #PAPERLESS_MEDIADIR=/path/to/media
 
+# Override the default STATIC_ROOT here. This is where all static files created
+# using "collectstatic" manager command are stored.
+#PAPERLESS_STATICDIR=""
+
 # The number of seconds that Paperless will wait between checking
 # PAPERLESS_CONSUMPTION_DIR.  If you tend to write documents to this directory
 # very slowly, you may want to use a higher value than the default (10).

--- a/src/paperless/checks.py
+++ b/src/paperless/checks.py
@@ -49,6 +49,20 @@ def paths_check(app_configs, **kwargs):
                     writeable_hint.format(directory)
                 ))
 
+    directory = os.getenv("PAPERLESS_STATICDIR")
+    if directory:
+        if not os.path.exists(directory):
+            check_messages.append(Error(
+                exists_message.format("PAPERLESS_STATICDIR"),
+                exists_hint.format(directory)
+            ))
+        if not check_messages:
+            if not os.access(directory, os.W_OK | os.X_OK):
+                check_messages.append(Error(
+                    writeable_message.format("PAPERLESS_STATICDIR"),
+                    writeable_hint.format(directory)
+                ))
+
     return check_messages
 
 

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -162,7 +162,8 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.9/howto/static-files/
 
-STATIC_ROOT = os.path.join(BASE_DIR, "..", "static")
+STATIC_ROOT = os.getenv(
+    "PAPERLESS_STATICDIR", os.path.join(BASE_DIR, "..", "static"))
 MEDIA_ROOT = os.getenv(
     "PAPERLESS_MEDIADIR", os.path.join(BASE_DIR, "..", "media"))
 


### PR DESCRIPTION
Like PAPERLESS_MEDIADIR this add option to also override STATIC_ROOT.

My setup use an external directory for STATIC files created using _manager.py collectstatic_ and this would make maintaining paperless sources easier by having settings.py untouched.