### PR TITLE
Fix/api should allow writes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 #########
 
+* 0.3.6
+  * Fix for `#200`_ (!!) where the API wasn't configured to allow updating the
+    correspondent or the tags for a document.
+
 * 0.3.5
   * A serious facelift for the documents listing page wherein we drop the
     tabular layout in favour of a tiled interface.
@@ -187,3 +191,4 @@ Changelog
 .. _#171: https://github.com/danielquinn/paperless/issues/171
 .. _#172: https://github.com/danielquinn/paperless/issues/172
 .. _#179: https://github.com/danielquinn/paperless/pull/179
+.. _#200: https://github.com/danielquinn/paperless/issues/200

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -18,12 +18,21 @@ class TagSerializer(serializers.HyperlinkedModelSerializer):
             "id", "slug", "name", "colour", "match", "matching_algorithm")
 
 
+class CorrespondentField(serializers.HyperlinkedRelatedField):
+    def get_queryset(self):
+        return Correspondent.objects.all()
+
+
+class TagsField(serializers.HyperlinkedRelatedField):
+    def get_queryset(self):
+        return Tag.objects.all()
+
+
 class DocumentSerializer(serializers.ModelSerializer):
 
-    correspondent = serializers.HyperlinkedRelatedField(
-        read_only=True, view_name="drf:correspondent-detail", allow_null=True)
-    tags = serializers.HyperlinkedRelatedField(
-        read_only=True, view_name="drf:tag-detail", many=True)
+    correspondent = CorrespondentField(
+        view_name="drf:correspondent-detail", allow_null=True)
+    tags = TagsField(view_name="drf:tag-detail", many=True)
 
     class Meta(object):
         model = Document


### PR DESCRIPTION
The documents API was pretty limited, not even allowing for the changing of the correspondent or tags.  This was due to how I was lazy when writing it way-back-when and didn't bother to figure out why DRF was complaining about how I'd declared the `correspondent` and `tags` values.  It was easier to just set `read_only=True` and walk away.  Oops.

Fixes #200.