### PR TITLE
paperless.conf.example: remove duplicate option

### DIFF
--- a/paperless.conf.example
+++ b/paperless.conf.example
@@ -109,9 +109,6 @@ PAPERLESS_SHARED_SECRET=""
 # Override the default UTC time zone here
 #PAPERLESS_TIME_ZONE=UTC
 
-# Customize number of list items to show per page
-#PAPERLESS_LIST_PER_PAGE=50
-
 # Customize the default language that tesseract will attempt to use when parsing
 # documents.  It should be a 3-letter language code consistent with ISO 639.
 #PAPERLESS_OCR_LANGUAGE=eng


### PR DESCRIPTION
This commit removes the duplicated option in this config:
please see https://github.com/danielquinn/paperless/blob/057d5f149fd63a34ebdd0fd00332e307ebcc3f95/paperless.conf.example#L113 compared with https://github.com/danielquinn/paperless/blob/057d5f149fd63a34ebdd0fd00332e307ebcc3f95/paperless.conf.example#L122