### PR TITLE
Bump pyocr requirement to version 0.4.7 to support tesseract 4.0.0alpha.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ djangorestframework>=3.5.3
 filemagic>=1.6
 fuzzywuzzy[speedup]==0.15.0
 langdetect>=1.0.7
-pyocr>=0.4.6
+pyocr>=0.4.7
 python-dateutil>=2.6.0
 python-dotenv>=0.6.2
 python-gnupg>=0.3.9


### PR DESCRIPTION
The [latest pyocr version](https://github.com/openpaperwork/pyocr/commit/85a011c4127b1faebd4890b9b423d692db5c3a08) now allows running pyocr with the latest tesseract version compiled from the tesseract master branch.

My oldish Ubuntu ships an ancient tesseract version, and being able to just compile and use the latest tesseract fills me with joy. Also, I hope that it produces better OCR results.

**Testing this**
On my setup it was simply a case of checking out the tesseract [master branch](https://github.com/tesseract-ocr/tesseract) and compiling + installing from there. It seems to work fine with paperless from the handful of documents I tried it with.