### PR TITLE
Set email inbox in config file, fetch email at consumer startup and bring documentation up to date

### DIFF
--- a/docs/consumption.rst
+++ b/docs/consumption.rst
@@ -134,6 +134,8 @@ So, with all that in mind, here's what you do to get it running:
    so if you set the subject to ``Correspondent - Title - tag,tag,tag``, you'll
    get what you expect.  Also, you must include the aforementioned secret
    string in every email so the fetcher knows that it's safe to import.
+   Note that Paperless only allows the email title to consist of safe characters
+   to be imported. These consist of alpha-numeric characters and ``-_ ,.'``.
 5. After a few minutes, the consumer will poll your mailbox, pull down the
    message, and place the attachment in the consumption directory with the
    appropriate name.  A few minutes later, the consumer will import it like any

--- a/docs/consumption.rst
+++ b/docs/consumption.rst
@@ -121,14 +121,15 @@ So, with all that in mind, here's what you do to get it running:
 
 1. Setup a new email account somewhere, or if you're feeling daring, create a
    folder in an existing email box and note the path to that folder.
-2. In ``settings.py`` set all of the appropriate values in ``MAIL_CONSUMPTION``.
+2. In ``/etc/paperless.conf`` set all of the appropriate values in
+   ``PATHS AND FOLDERS`` and ``SECURITY``.
    If you decided to use a subfolder of an existing account, then make sure you
-   set ``INBOX`` accordingly here.  You also have to set the
-   ``UPLOAD_SHARED_SECRET`` to something you can remember 'cause you'll have to
-   include that in every email you send.
+   set ``PAPERLESS_CONSUME_MAIL_INBOX`` accordingly here.  You also have to set
+   the ``PAPERLESS_SHARED_SECRET`` to something you can remember 'cause you'll
+   have to include that in every email you send.
 3. Restart the :ref:`consumer <utilities-consumer>`.  The consumer will check
-   the configured email account every 10 minutes for something new and pull down
-   whatever it finds.
+   the configured email account at startup and from then on every 10 minutes
+   for something new and pulls down whatever it finds.
 4. Send yourself an email!  Note that the subject is treated as the file name,
    so if you set the subject to ``Correspondent - Title - tag,tag,tag``, you'll
    get what you expect.  Also, you must include the aforementioned secret

--- a/paperless.conf.example
+++ b/paperless.conf.example
@@ -37,7 +37,7 @@ PAPERLESS_CONSUME_MAIL_PORT=""
 PAPERLESS_CONSUME_MAIL_USER=""
 PAPERLESS_CONSUME_MAIL_PASS=""
 
-# Override the default IMAP inbox here. If not set paperless defaults to
+# Override the default IMAP inbox here. If not set Paperless defaults to
 # "INBOX".
 #PAPERLESS_CONSUME_MAIL_INBOX=""
 

--- a/paperless.conf.example
+++ b/paperless.conf.example
@@ -37,6 +37,10 @@ PAPERLESS_CONSUME_MAIL_PORT=""
 PAPERLESS_CONSUME_MAIL_USER=""
 PAPERLESS_CONSUME_MAIL_PASS=""
 
+# Override the default IMAP inbox here. If not set paperless defaults to
+# "INBOX".
+#PAPERLESS_CONSUME_MAIL_INBOX=""
+
 
 ###############################################################################
 ####                              Security                                 ####

--- a/src/documents/mail.py
+++ b/src/documents/mail.py
@@ -219,7 +219,7 @@ class MailFetcher(Loggable):
         if not login[0] == "OK":
             raise MailFetcherError("Can't log into mail: {}".format(login[1]))
 
-        inbox = self._connection.select("INBOX")
+        inbox = self._connection.select(self._inbox)
         if not inbox[0] == "OK":
             raise MailFetcherError("Can't find the inbox: {}".format(inbox[1]))
 

--- a/src/documents/management/commands/document_consumer.py
+++ b/src/documents/management/commands/document_consumer.py
@@ -28,6 +28,7 @@ class Command(BaseCommand):
 
         self.file_consumer = None
         self.mail_fetcher = None
+        self.first_iteration = True
 
         BaseCommand.__init__(self, *args, **kwargs)
 
@@ -66,6 +67,9 @@ class Command(BaseCommand):
         self.file_consumer.consume()
 
         # Occasionally fetch mail and store it to be consumed on the next loop
+        # We fetch email when we first start up so that it is not necessary to
+        # wait for 10 minutes after making changes to the config file.
         delta = self.mail_fetcher.last_checked + self.MAIL_DELTA
-        if delta < datetime.datetime.now():
+        if self.first_iteration or delta < datetime.datetime.now():
+            self.first_iteration = False
             self.mail_fetcher.pull()

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -244,8 +244,10 @@ MAIL_CONSUMPTION = {
     "PORT": os.getenv("PAPERLESS_CONSUME_MAIL_PORT"),
     "USERNAME": os.getenv("PAPERLESS_CONSUME_MAIL_USER"),
     "PASSWORD": os.getenv("PAPERLESS_CONSUME_MAIL_PASS"),
-    "USE_SSL": os.getenv("PAPERLESS_CONSUME_MAIL_USE_SSL", "y").lower() == "y",  # If True, use SSL/TLS to connect
-    "INBOX": "INBOX"  # The name of the inbox on the server
+    # If True, use SSL/TLS to connect
+    "USE_SSL": os.getenv("PAPERLESS_CONSUME_MAIL_USE_SSL", "y").lower() == "y",
+    # The name of the inbox on the server
+    "INBOX": os.getenv("PAPERLESS_CONSUME_MAIL_INBOX", "INBOX")
 }
 
 # This is used to encrypt the original documents and decrypt them later when


### PR DESCRIPTION
I have been setting up the email consumption on my setup and noticed some bits where the docs are not current or trying out changes could be easier. Hence this pull request. Basically:

* Fetch emails at startup of the consumer so that after a config change it is immediately clear whether it works or not. I wondered whether this could be an issue if there is no internet connection yet at startup, but Paperless seems to handle that fine as it only prints an error but does not break.
* Allow to set the email inbox in the config file together with the other options.
* Bring the documentation of the email section up to date with the current implementation

Thanks!