### PR TITLE
Add django_filters to INSTALLED_APPS

### DIFF
--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -69,6 +69,7 @@ INSTALLED_APPS = [
 
     "rest_framework",
     "crispy_forms",
+    "django_filters"
 
 ]
 


### PR DESCRIPTION
This prevents template does not exist rendering errors when visiting /api/* routes under certain 'django_filter' versions. Adding it to INSTALLED_APPS lets the templates be found more consistently. This fix was found [here](https://github.com/carltongibson/django-filter/issues/562), [here](https://github.com/carltongibson/django-filter/issues/666), and was also needed in [this other project](https://github.com/dunbarcyber/cyphon/commit/7f090092f04033592df85af07450323a7f5a728c). After adding this all routes worked again for me.