### PR TITLE
Fix http post

### DIFF
--- a/src/documents/forms.py
+++ b/src/documents/forms.py
@@ -2,7 +2,6 @@ import magic
 import os
 
 from datetime import datetime
-from hashlib import sha256
 from time import mktime
 
 from django import forms
@@ -32,10 +31,9 @@ class UploadForm(forms.Form):
         required=False
     )
     document = forms.FileField()
-    signature = forms.CharField(max_length=256)
 
     def __init__(self, *args, **kwargs):
-        forms.Form.__init__(*args, **kwargs)
+        forms.Form.__init__(self, *args, **kwargs)
         self._file_type = None
 
     def clean_correspondent(self):
@@ -82,17 +80,6 @@ class UploadForm(forms.Form):
 
         return document
 
-    def clean(self):
-
-        corresp = self.cleaned_data.get("correspondent")
-        title = self.cleaned_data.get("title")
-        signature = self.cleaned_data.get("signature")
-
-        if sha256(corresp + title + self.SECRET).hexdigest() == signature:
-            return self.cleaned_data
-
-        raise forms.ValidationError("The signature provided did not validate")
-
     def save(self):
         """
         Since the consumer already does a lot of work, it's easier just to save
@@ -104,7 +91,7 @@ class UploadForm(forms.Form):
         title = self.cleaned_data.get("title")
         document = self.cleaned_data.get("document")
 
-        t = int(mktime(datetime.now()))
+        t = int(mktime(datetime.now().timetuple()))
         file_name = os.path.join(
             Consumer.CONSUME,
             "{} - {}.{}".format(correspondent, title, self._file_type)

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -1,5 +1,4 @@
-from django.http import HttpResponse
-from django.views.decorators.csrf import csrf_exempt
+from django.http import HttpResponse, HttpResponseBadRequest
 from django.views.generic import DetailView, FormView, TemplateView
 from django_filters.rest_framework import DjangoFilterBackend
 from paperless.db import GnuPG
@@ -81,15 +80,12 @@ class PushView(SessionOrBasicAuthMixin, FormView):
 
     form_class = UploadForm
 
-    @classmethod
-    def as_view(cls, **kwargs):
-        return csrf_exempt(FormView.as_view(**kwargs))
-
     def form_valid(self, form):
-        return HttpResponse("1")
+        form.save()
+        return HttpResponse("1", status=202)
 
     def form_invalid(self, form):
-        return HttpResponse("0")
+        return HttpResponseBadRequest(str(form.errors))
 
 
 class CorrespondentViewSet(ModelViewSet):

--- a/src/paperless/urls.py
+++ b/src/paperless/urls.py
@@ -1,19 +1,3 @@
-"""paperless URL Configuration
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/1.10/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
-Including another URLconf
-    1. Add an import:  from blog import urls as blog_urls
-    2. Import the include() function: from django.conf.urls import url, include
-    3. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
-"""
 from django.conf import settings
 from django.conf.urls import url, static, include
 from django.contrib import admin
@@ -21,7 +5,7 @@ from django.contrib import admin
 from rest_framework.routers import DefaultRouter
 
 from documents.views import (
-    IndexView, FetchView, PushView,
+    FetchView, PushView,
     CorrespondentViewSet, TagViewSet, DocumentViewSet, LogViewSet
 )
 from reminders.views import ReminderViewSet
@@ -41,9 +25,6 @@ urlpatterns = [
         include('rest_framework.urls', namespace="rest_framework")
     ),
     url(r"^api/", include(router.urls, namespace="drf")),
-
-    # Normal pages (coming soon)
-    # url(r"^$", IndexView.as_view(), name="index"),
 
     # File downloads
     url(

--- a/src/paperless/urls.py
+++ b/src/paperless/urls.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.conf.urls import url, static, include
 from django.contrib import admin
+from django.views.decorators.csrf import csrf_exempt
 
 from rest_framework.routers import DefaultRouter
 
@@ -40,7 +41,10 @@ urlpatterns = [
 ] + static.static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 if settings.SHARED_SECRET:
-    urlpatterns.insert(0, url(r"^push$", PushView.as_view(), name="push"))
+    urlpatterns.insert(
+        0,
+        url(r"^push$", csrf_exempt(PushView.as_view()), name="push")
+    )
 
 # Text in each page's <h1> (and above login form).
 admin.site.site_header = 'Paperless'


### PR DESCRIPTION
Fixes #236 

Big thanks to @jmgilman for taking the time to find these bugs and harass me about them.  I hadn't realised that the POST code was such a mess, but I'm pretty sure that in the state that it was in, it never worked for anyone.

This PR does the following:

    * Removes the requirement for signature generation in favour of simply
      requiring BasicAuth or a valid session id.
    * Fixes a number of bugs in the form itself that would have ensured that
      the form never accepted anything.
    * Documents it all properly so now (hopefully) people will have less
      trouble figuring it out in the future.

It's now 0130h so I'm not going to merge this into `master` just yet.  However if someone wants to give it a test drive, that wouldn't suck :-)