### PR TITLE
Add link to Django documentation for time zone setting in example config.

### DIFF
--- a/paperless.conf.example
+++ b/paperless.conf.example
@@ -156,7 +156,9 @@ PAPERLESS_PASSPHRASE="secret"
 ####                            Interface                                  ####
 ###############################################################################
 
-# Override the default UTC time zone here
+# Override the default UTC time zone here.
+# See https://docs.djangoproject.com/en/1.10/ref/settings/#std:setting-TIME_ZONE
+# for details on how to set it.
 #PAPERLESS_TIME_ZONE=UTC
 
 


### PR DESCRIPTION
Trivial pull request but I was struggling with this twice already so I'm thinking it is good to include.

It is not obvious which time zones the option in the config file accepts. Having a link to the official django documentation makes it clear.

Thanks!