### PR TITLE
Mention "collectstatic" in the docs

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -394,7 +394,10 @@ Using a Real Webserver
 The default is to use Django's development server, as that's easy and does the
 job well enough on a home network.  However, if you want to do things right,
 it's probably a good idea to use a webserver capable of handling more than one
-thread.
+thread. You will also have to let the webserver serve the static files (CSS,
+JavaScript) from the directory configured in ``PAPERLESS_STATICDIR``. For that,
+you need to run ``./manage.py collectstatic`` in the ``src`` directory.  The
+default static files directory is ``../static``.
 
 Apache
 ~~~~~~


### PR DESCRIPTION
When using the built-in webserver in debug mode, the static files are
handled automatically. From the Django docs:

	During development, if you use django.contrib.staticfiles, this will
	be done automatically by runserver when DEBUG is set to True (see
	django.contrib.staticfiles.views.serve()).

	This method is grossly inefficient and probably insecure, so it is
	unsuitable for production.

This means, when using a real webserver, it also has to serve the static
files, i.e.  CSS and JavaScript. For that, one needs to run `./manage.py
collectstatic` first.

---

Sorry, if my comment came accross rude. You did a great job with this app. I only wanted to explain, why I might know about the problem, even though I didn't use docker.