### PR TITLE
create documents subfolder folder if they do not exist

### DIFF
--- a/src/documents/migrations/0012_auto_20160305_0040.py
+++ b/src/documents/migrations/0012_auto_20160305_0040.py
@@ -38,6 +38,9 @@ class GnuPG(object):
 
 def move_documents_and_create_thumbnails(apps, schema_editor):
 
+    os.makedirs(os.path.join(settings.MEDIA_ROOT, "documents", "originals"), exist_ok=True)
+    os.makedirs(os.path.join(settings.MEDIA_ROOT, "documents", "thumbnails"), exist_ok=True)
+
     documents = os.listdir(os.path.join(settings.MEDIA_ROOT, "documents"))
 
     if set(documents) == {"originals", "thumbnails"}:


### PR DESCRIPTION
Create documents and subfolder in migration if they do not exist. This could happen if you start a new installation without creating these folders manually.