### PR TITLE
Added option to disable encryption

### DIFF
--- a/src/manage.py
+++ b/src/manage.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
     # The runserver and consumer need to have access to the passphrase, so it
     # must be entered at start time to keep it safe.
     if "runserver" in sys.argv or "document_consumer" in sys.argv:
-        if not settings.PASSPHRASE:
+        if(settings.ENABLE_ENCRYPTION and not settings.PASSPHRASE):
             settings.PASSPHRASE = input(
                 "settings.PASSPHRASE is unset.  Input passphrase: ")
 

--- a/src/paperless/db.py
+++ b/src/paperless/db.py
@@ -12,11 +12,15 @@ class GnuPG(object):
 
     @classmethod
     def decrypted(cls, file_handle):
+        if(not settings.ENABLE_ENCRYPTION):
+            return file_handle.read()
         return cls.gpg.decrypt_file(
             file_handle, passphrase=settings.PASSPHRASE).data
 
     @classmethod
     def encrypted(cls, file_handle):
+        if(not settings.ENABLE_ENCRYPTION):
+            return file_handle.read()
         return cls.gpg.encrypt_file(
             file_handle,
             recipients=None,

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -245,6 +245,7 @@ CONSUMER_LOOP_TIME = int(os.getenv("PAPERLESS_CONSUMER_LOOP_TIME", 10))
 # with GPG, including an interesting case where it may "encrypt" zero-byte
 # files.
 PASSPHRASE = os.getenv("PAPERLESS_PASSPHRASE")
+ENABLE_ENCRYPTION = os.getenv('DISABLE_ENCRYPTION') != 'true'
 
 # Trigger a script after every successful document consumption?
 PRE_CONSUME_SCRIPT = os.getenv("PAPERLESS_PRE_CONSUME_SCRIPT")


### PR DESCRIPTION
I prefer to store my files in their raw form (already using full-disk encryption underneath), and stumbled across #188.

I noted your comment that the change was a bit heavy-handed - and after reviewing it I think that's putting it mildly :) - I think this will be more palatable.

Encryption stays enabled by default.  If the `DISABLE_ENCRYPTION` environment variable is set to `'true'`, then we (A) don't prompt for a passphrase when we find that it's empty on startup, and (B) just return the file's raw contents from `encrypted()` and `decrypted()` in `src/paperless/db.py`

Semantically speaking, I don't love doing it in those functions, but practically speaking, it seemed like the minimal possible change to achieve my goal.