### PR TITLE
add FORCE_SCRIPT_NAME to host paperless on a subpath url

### DIFF
--- a/paperless.conf.example
+++ b/paperless.conf.example
@@ -80,6 +80,11 @@ PAPERLESS_PASSPHRASE="secret"
 # as is "example.com,www.example.com", but NOT " example.com" or "example.com,"
 #PAPERLESS_ALLOWED_HOSTS="example.com,www.example.com"
 
+# To host paperless under a subpath url like example.com/paperless you set
+# this value to /paperless. No trailing slash!
+#
+# https://docs.djangoproject.com/en/1.11/ref/settings/#force-script-name
+#PAPERLESS_FORCE_SCRIPT_NAME=""
 
 ###############################################################################
 ####                          Software Tweaks                              ####

--- a/src/documents/admin.py
+++ b/src/documents/admin.py
@@ -71,12 +71,12 @@ class DocumentAdmin(CommonAdmin):
 
     def thumbnail(self, obj):
         if settings.FORCE_SCRIPT_NAME:
-            _src="{}/fetch/thumb/{}".format(settings.FORCE_SCRIPT_NAME,obj.id)
+            src_link = "{}/fetch/thumb/{}".format(settings.FORCE_SCRIPT_NAME, obj.id)
         else:
-            _src="/fetch/thumb/{}".format(obj.id)
+            src_link = "/fetch/thumb/{}".format(obj.id)
         png_img = self._html_tag(
             "img",
-            src=_src,
+            src=src_link,
             width=180,
             alt="Thumbnail of {}".format(obj.file_name),
             title=obj.file_name

--- a/src/documents/admin.py
+++ b/src/documents/admin.py
@@ -70,9 +70,13 @@ class DocumentAdmin(CommonAdmin):
     created_.short_description = "Created"
 
     def thumbnail(self, obj):
+        if settings.FORCE_SCRIPT_NAME:
+            _src="{}/fetch/thumb/{}".format(settings.FORCE_SCRIPT_NAME,obj.id)
+        else:
+            _src="/fetch/thumb/{}".format(obj.id)
         png_img = self._html_tag(
             "img",
-            src="/fetch/thumb/{}".format(obj.id),
+            src=_src,
             width=180,
             alt="Thumbnail of {}".format(obj.file_name),
             title=obj.file_name

--- a/src/documents/admin.py
+++ b/src/documents/admin.py
@@ -71,7 +71,8 @@ class DocumentAdmin(CommonAdmin):
 
     def thumbnail(self, obj):
         if settings.FORCE_SCRIPT_NAME:
-            src_link = "{}/fetch/thumb/{}".format(settings.FORCE_SCRIPT_NAME, obj.id)
+            src_link = "{}/fetch/thumb/{}".format(
+                settings.FORCE_SCRIPT_NAME, obj.id)
         else:
             src_link = "/fetch/thumb/{}".format(obj.id)
         png_img = self._html_tag(

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -47,7 +47,11 @@ _allowed_hosts = os.getenv("PAPERLESS_ALLOWED_HOSTS")
 if _allowed_hosts:
     ALLOWED_HOSTS = _allowed_hosts.split(",")
 
-
+FORCE_SCRIPT_NAME = None
+_force_script_name = os.getenv("PAPERLESS_FORCE_SCRIPT_NAME")
+if _force_script_name:
+    FORCE_SCRIPT_NAME = _force_script_name
+    
 # Application definition
 
 INSTALLED_APPS = [

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -47,10 +47,7 @@ _allowed_hosts = os.getenv("PAPERLESS_ALLOWED_HOSTS")
 if _allowed_hosts:
     ALLOWED_HOSTS = _allowed_hosts.split(",")
 
-FORCE_SCRIPT_NAME = None
-_force_script_name = os.getenv("PAPERLESS_FORCE_SCRIPT_NAME")
-if _force_script_name:
-    FORCE_SCRIPT_NAME = _force_script_name
+FORCE_SCRIPT_NAME = os.getenv("PAPERLESS_FORCE_SCRIPT_NAME")
     
 # Application definition
 


### PR DESCRIPTION
I host paperless on raspberrypi/paperless. This should do the trick.