### PR TITLE
Add financial year documents filter

### DIFF
--- a/paperless.conf.example
+++ b/paperless.conf.example
@@ -162,6 +162,12 @@ PAPERLESS_PASSPHRASE="secret"
 #PAPERLESS_TIME_ZONE=UTC
 
 
+# If set, Paperless will show document filters per financial year.
+# The dates must be in the format "mm-dd", for example "07-15" for July 15.
+#PAPERLESS_FINANCIAL_YEAR_START="mm-dd"
+#PAPERLESS_FINANCIAL_YEAR_END="mm-dd"
+
+
 # The number of items on each page in the web UI.  This value must be a
 # positive integer, but if you don't define one in paperless.conf, a default of
 # 100 will be used.

--- a/src/documents/admin.py
+++ b/src/documents/admin.py
@@ -63,9 +63,9 @@ class FinancialYearFilter(admin.SimpleListFilter):
 
     def _determine_fy(self, date):
         """Return a (query, display) financial year tuple of the given date."""
-        fy_start = self._fy_start(date.year)
-
         if self._fy_does_wrap():
+            fy_start = self._fy_start(date.year)
+
             if date.date() >= fy_start:
                 query = "{}-{}".format(date.year, date.year + 1)
             else:

--- a/src/documents/admin.py
+++ b/src/documents/admin.py
@@ -38,6 +38,7 @@ class FinancialYearFilter(admin.SimpleListFilter):
 
     title = "Financial Year"
     parameter_name = "fy"
+    _fy_wraps = None
 
     def _fy_start(self, year):
         """Return date of the start of financial year for the given year."""
@@ -51,12 +52,14 @@ class FinancialYearFilter(admin.SimpleListFilter):
 
     def _fy_does_wrap(self):
         """Return whether the financial year spans across two years."""
-        start = "{}".format(settings.FY_START)
-        start = datetime.strptime(start, "%m-%d").date()
-        end = "{}".format(settings.FY_END)
-        end = datetime.strptime(end, "%m-%d").date()
+        if self._fy_wraps is None:
+            start = "{}".format(settings.FY_START)
+            start = datetime.strptime(start, "%m-%d").date()
+            end = "{}".format(settings.FY_END)
+            end = datetime.strptime(end, "%m-%d").date()
+            self._fy_wraps = end < start
 
-        return end < start
+        return self._fy_wraps
 
     def _determine_fy(self, date):
         """Return a (query, display) financial year tuple of the given date."""

--- a/src/documents/admin.py
+++ b/src/documents/admin.py
@@ -41,12 +41,14 @@ class FinancialYearFilter(admin.SimpleListFilter):
 
     def _fy_start(self, year):
         """Return date of the start of financial year for the given year."""
-        fy_start = "{}-07-01".format(str(year))
+        assert settings.FY_START
+        fy_start = "{}-{}".format(str(year), settings.FY_START)
         return datetime.strptime(fy_start, "%Y-%m-%d").date()
 
     def _fy_end(self, year):
         """Return date of the end of financial year for the given year."""
-        fy_end = "{}-06-30".format(str(year))
+        assert settings.FY_END
+        fy_end = "{}-{}".format(str(year), settings.FY_END)
         return datetime.strptime(fy_end, "%Y-%m-%d").date()
 
     def _determine_fy(self, date):
@@ -105,7 +107,11 @@ class DocumentAdmin(CommonAdmin):
 
     search_fields = ("correspondent__name", "title", "content")
     list_display = ("title", "created", "thumbnail", "correspondent", "tags_")
-    list_filter = ("tags", "correspondent", FinancialYearFilter, MonthListFilter)
+    list_filter = ("tags", "correspondent")
+    if settings.FY_START and settings.FY_END:
+        list_filter += (FinancialYearFilter,)
+    list_filter += (MonthListFilter,)
+
     ordering = ["-created", "correspondent"]
 
     def has_add_permission(self, request):

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -254,3 +254,6 @@ POST_CONSUME_SCRIPT = os.getenv("PAPERLESS_POST_CONSUME_SCRIPT")
 # positive integer, but if you don't define one in paperless.conf, a default of
 # 100 will be used.
 PAPERLESS_LIST_PER_PAGE = int(os.getenv("PAPERLESS_LIST_PER_PAGE", 100))
+
+FY_START = os.getenv("PAPERLESS_FINANCIAL_YEAR_START")
+FY_END = os.getenv("PAPERLESS_FINANCIAL_YEAR_END")


### PR DESCRIPTION
I'm using Paperless to store my tax documents and being able to filter by financial year is quite handy. So, this pull request brings in support for a financial year filter.

The start and end date must be set in the config but everything else pretty much just works. Both financial years that go from Jan-Dec as well as for example Jul-Jun work.

<img width="271" alt="screen shot 2017-08-26 at 8 05 03 pm" src="https://user-images.githubusercontent.com/710898/29740432-f1503d00-8a99-11e7-99e9-ac9f3bf97beb.png">

Thanks!