### PR TITLE
PAPERLESS_OCR_LANGUAGES -> PAPERLESS_OCR_LANGUAGE

### DIFF
--- a/docker-compose.env.example
+++ b/docker-compose.env.example
@@ -8,7 +8,7 @@ PAPERLESS_PASSPHRASE=CHANGE_ME
 # PAPERLESS_OCR_THREADS=4
 
 # Additional languages to install for text recognition
-# PAPERLESS_OCR_LANGUAGES=deu ita
+# PAPERLESS_OCR_LANGUAGE=deu ita
 
 # You can change the default user and group id to a custom one
 # USERMAP_UID=1000

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -16,7 +16,7 @@ services:
         # languages the user might have set in the env-file by overwriting the
         # value with nothing.
         environment:
-            - PAPERLESS_OCR_LANGUAGES=
+            - PAPERLESS_OCR_LANGUAGE=
         command: ["runserver", "0.0.0.0:8000"]
 
     consumer:

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -187,7 +187,7 @@ Docker Method
      document pages in parallel. If the variable is not set, Python determines
      the core-count of your CPU and uses that value.
 
-   ``PAPERLESS_OCR_LANGUAGES``
+   ``PAPERLESS_OCR_LANGUAGE``
      If you want the OCR to recognize other languages in addition to the
      default English, set this parameter to a space separated list of
      three-letter language-codes after `ISO 639-2/T`_. For a list of available

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -82,8 +82,8 @@ if [[ "$1" != "/"* ]]; then
     initialize
 
     # Install additional languages if specified
-    if [ ! -z "$PAPERLESS_OCR_LANGUAGES"  ]; then
-        install_languages "$PAPERLESS_OCR_LANGUAGES"
+    if [ ! -z "$PAPERLESS_OCR_LANGUAGE"  ]; then
+        install_languages "$PAPERLESS_OCR_LANGUAGE"
     fi
 
     exec sudo -HEu paperless "/usr/src/paperless/src/manage.py" "$@"


### PR DESCRIPTION
I've seen discrepancies in the documentation regarding the use of both `PAPERLESS_OCR_LANGUAGES` and `PAPERLESS_OCR_LANGUAGE` (note singular/plural) and looking at the source I came to believe only the singular version is being used.

What I did is, I changed the plural versions to the singular version to avoid confusion and stay conform to what is being evaluated in code.

Please correct me if I'm wrong here