### PR TITLE
Change default /consume volume

### DIFF
--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -26,7 +26,7 @@ services:
             - media:/usr/src/paperless/media
             # You have to adapt the local path you want the consumption
             # directory to mount to by modifying the part before the ':'.
-            - /path/to/arbitrary/place:/consume
+            - ./consume:/consume
             # Likewise, you can add a local path to mount a directory for
             # exporting. This is not strictly needed for paperless to
             # function, only if you're exporting your files: uncomment


### PR DESCRIPTION
Change default /consume volume to ./consume on your host, so that no unexpected folder will be generated on the host machine.

See discussion here: https://github.com/danielquinn/paperless/issues/267#issuecomment-341188363