### PR TITLE
#248: fix missing CSS

### DIFF
--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -17,7 +17,7 @@ services:
         # value with nothing.
         environment:
             - PAPERLESS_OCR_LANGUAGES=
-        command: ["runserver", "0.0.0.0:8000"]
+        command: ["runserver", "--insecure", "0.0.0.0:8000"]
 
     consumer:
         image: pitkley/paperless


### PR DESCRIPTION
Force the server to use --insecure flag to also provide static contents like CSS files.
See #248 and #167 for more details.