### PR TITLE
small typo in exporter thumbnail filename

### DIFF
--- a/src/documents/management/commands/document_exporter.py
+++ b/src/documents/management/commands/document_exporter.py
@@ -64,7 +64,7 @@ class Command(Renderable, BaseCommand):
 
             file_target = os.path.join(self.target, document.file_name)
 
-            thumbnail_name = document.file_name + "-tumbnail.png"
+            thumbnail_name = document.file_name + "-thumbnail.png"
             thumbnail_target = os.path.join(self.target, thumbnail_name)
 
             document_dict[EXPORTER_FILE_NAME] = document.file_name


### PR DESCRIPTION
The typo doesn't affect functionality, since whatever filename is used gets written to `manifest.json`, and that is what is used to import. So this is purely cosmetic.