### PR TITLE
Fixing error sentinel for pdftotext when the PDF has no text (scanned…

### DIFF
--- a/src/paperless_tesseract/parsers.py
+++ b/src/paperless_tesseract/parsers.py
@@ -235,6 +235,6 @@ def get_text_from_pdf(pdf_file):
         try:
             pdf = pdftotext.PDF(f)
         except pdftotext.Error:
-            return False
+            return ""
 
     return "\n".join(pdf)


### PR DESCRIPTION
… images). It was causing a crash previously.