### PR TITLE
Handle Django migrations at startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,6 @@ RUN apk --no-cache --update add \
     apk del .build-dependencies && \
 # Create the consumption directory
     mkdir -p $PAPERLESS_CONSUMPTION_DIR && \
-# Migrate database
-    ./src/manage.py migrate && \
 # Create user
     addgroup -g 1000 paperless && \
     adduser -D -u 1000 -G paperless -h /usr/src/paperless paperless && \

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -3,13 +3,13 @@ version: '2.1'
 services:
     webserver:
         build: ./
-	# uncomment the following line to start automatically on system boot
-	# restart: always
+        # uncomment the following line to start automatically on system boot
+        # restart: always
         ports:
             # You can adapt the port you want Paperless to listen on by
             # modifying the part before the `:`.
             - "8000:8000"
-	healthcheck:
+        healthcheck:
             test: ["CMD", "curl" , "-f", "http://localhost:8000"]
             interval: 30s
             timeout: 10s
@@ -28,9 +28,9 @@ services:
 
     consumer:
         build: ./
-	# uncomment the following line to start automatically on system boot
-	# restart: always
-	depends_on:
+        # uncomment the following line to start automatically on system boot
+        # restart: always
+        depends_on:
             webserver:
                 condition: service_healthy
         volumes:

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -1,12 +1,19 @@
-version: '2'
+version: '2.1'
 
 services:
     webserver:
         build: ./
+	# uncomment the following line to start automatically on system boot
+	# restart: always
         ports:
             # You can adapt the port you want Paperless to listen on by
             # modifying the part before the `:`.
             - "8000:8000"
+	healthcheck:
+            test: ["CMD", "curl" , "-f", "http://localhost:8000"]
+            interval: 30s
+            timeout: 10s
+            retries: 5
         volumes:
             - data:/usr/src/paperless/data
             - media:/usr/src/paperless/media
@@ -21,6 +28,11 @@ services:
 
     consumer:
         build: ./
+	# uncomment the following line to start automatically on system boot
+	# restart: always
+	depends_on:
+            webserver:
+                condition: service_healthy
         volumes:
             - data:/usr/src/paperless/data
             - media:/usr/src/paperless/media

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -94,7 +94,7 @@ You may want to take a look at the ``paperless.conf.example`` file to see if
 there's anything new in there compared to what you've got int ``/etc``.
 
 If you are :ref:`using Docker <setup-installation-docker>` the update process
-requires only one additional step:
+is similar:
 
 .. code-block:: shell-session
 
@@ -102,7 +102,6 @@ requires only one additional step:
     $ git pull
     $ docker build -t paperless .
     $ docker-compose up -d
-    $ docker-compose run --rm webserver migrate
 
 If ``git pull`` doesn't report any changes, there is no need to continue with
 the remaining steps.

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -42,9 +42,24 @@ set_permissions() {
     chown -Rh paperless:paperless /usr/src/paperless
 }
 
+migrations() {
+    # A simple lock file in case other containers use this startup
+    LOCKFILE="/usr/src/paperless/data/db.sqlite3.migration"
+
+    set -o noclobber
+    # check for and create lock file in one command 
+    (> ${LOCKFILE}) &> /dev/null
+    if [ $? -eq 0 ]
+    then
+        sudo -HEu paperless "/usr/src/paperless/src/manage.py" "migrate"
+        rm ${LOCKFILE}
+    fi
+}
+
 initialize() {
     map_uidgid
     set_permissions
+    migrations
 }
 
 install_languages() {


### PR DESCRIPTION
Here is one solution to https://github.com/danielquinn/paperless/issues/299.
Basically, I've established a dependency between the two containers and moved the migration to the entrypoint. Startup takes a few more seconds now, while the health check is happening. 

I've also updated the docs and added an example restart policy to the compose example file. 