### PR TITLE
Log detected document date with isoformat

### DIFF
--- a/src/paperless_tesseract/parsers.py
+++ b/src/paperless_tesseract/parsers.py
@@ -242,7 +242,7 @@ class RasterisedDocumentParser(DocumentParser):
                 break
 
         if date is not None:
-            self.log("info", "Detected document date " + date.strftime("%x") +
+            self.log("info", "Detected document date " + date.isoformat() +
                              " based on string " + datestring)
         else:
             self.log("info", "Unable to detect date for document")


### PR DESCRIPTION
Logging the document date with the locale specific format can be confusing if the ocr language is not the same as the locale. 