### PR TITLE
Add curl as dependency in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV PAPERLESS_EXPORT_DIR=/export \
 
 # Install dependencies
 RUN apk --no-cache --update add \
-        python3 gnupg libmagic bash shadow \
+        python3 gnupg libmagic bash shadow curl \
         sudo poppler tesseract-ocr imagemagick ghostscript unpaper && \
     apk --no-cache add --virtual .build-dependencies \
         python3-dev poppler-dev gcc g++ musl-dev zlib-dev jpeg-dev && \


### PR DESCRIPTION
The health check in `docker-compose.yml` uses curl, but the `alpine:3.7` image this Dockerfile builds on doesn't include curl, leading to the health check failing:

    {
        "Start": "2018-03-06T20:48:57.293359619-06:00",
        "End": "2018-03-06T20:48:57.388576132-06:00",
        "ExitCode": -1,
        "Output": "OCI runtime exec failed: exec failed: container_linux.go:348: starting container process caused \"exec: \\\"curl\\\": executable file not found in $PATH\": unknown"
    }

This should be reproducible by simply following the docker-based installation instructions; without this change my `docker-compose up` fails because the health check fails. This change made the docker installation instructions work for me.