### PR TITLE
Use --noreload for permanent server start commands

### DIFF
--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -24,7 +24,7 @@ services:
         # value with nothing.
         environment:
             - PAPERLESS_OCR_LANGUAGES=
-        command: ["runserver", "--insecure", "0.0.0.0:8000"]
+        command: ["runserver", "--insecure", "--noreload", "0.0.0.0:8000"]
 
     consumer:
         build: ./

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -352,7 +352,7 @@ after restarting your system:
     respawn limit 10 5
 
     script
-      exec /srv/paperless/src/manage.py runserver 0.0.0.0:80
+      exec /srv/paperless/src/manage.py runserver --noreload 0.0.0.0:80
     end script
 
    Note that you'll need to replace ``/srv/paperless/src/manage.py`` with the

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -33,8 +33,11 @@ The webserver is started via the ``manage.py`` script:
 By default, the server runs on localhost, port 8000, but you can change this
 with a few arguments, run ``manage.py --help`` for more information.
 
-Note that this command runs continuously, so exiting it will mean your webserver
-disappears.  If you want to run this full-time (which is kind of the point)
+Add the option ``--noreload`` to reduce resource usage. Otherwise, the server
+continuously polls all source files for changes to auto-reload them.
+
+Note that when exiting this command your webserver will disappear.
+If you want to run this full-time (which is kind of the point)
 you'll need to have it start in the background -- something you'll need to
 figure out for your own system.  To get you started though, there are Systemd
 service files in the ``scripts`` directory.

--- a/scripts/paperless-webserver.service
+++ b/scripts/paperless-webserver.service
@@ -4,7 +4,7 @@ Description=Paperless webserver
 [Service]
 User=paperless
 Group=paperless
-ExecStart=/home/paperless/project/virtualenv/bin/python /home/paperless/project/src/manage.py runserver 0.0.0.0:8000
+ExecStart=/home/paperless/project/virtualenv/bin/python /home/paperless/project/src/manage.py runserver --noreload 0.0.0.0:8000
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Without it, the server is highly resource-intensive even when running idle.
On my system, it permanently consumed 30% of one core.

I've rephrased the paragraph starting with "Note that" in `utilities.rst` to avoid repeating the word "continuously".
