### PR TITLE
Fix runtime warning when adding log entries

### DIFF
--- a/src/documents/signals/handlers.py
+++ b/src/documents/signals/handlers.py
@@ -6,8 +6,7 @@ from django.conf import settings
 from django.contrib.admin.models import ADDITION, LogEntry
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
-
-from datetime import datetime
+from django.utils import timezone
 
 from ..models import Correspondent, Document, Tag
 
@@ -107,7 +106,7 @@ def set_log_entry(sender, document=None, logging_group=None, **kwargs):
 
     LogEntry.objects.create(
         action_flag=ADDITION,
-        action_time=datetime.now(),
+        action_time=timezone.now(),
         content_type=ct,
         object_id=document.id,
         user=user,


### PR DESCRIPTION
`LogEntry.action_time` expects a Django timezone object instead of a builtin datetime.

This fixes a runtime warning of the following kind:
```
RuntimeWarning: DateTimeField LogEntry.action_time received a naive datetime (2018-03-21 20:51:01.714123) while time zone support is active.
```