### PR TITLE
[Help needed] Increase link area in documents listing

### DIFF
--- a/src/documents/templates/admin/documents/document/change_list_results.html
+++ b/src/documents/templates/admin/documents/document/change_list_results.html
@@ -132,9 +132,10 @@
     {# 3: Image #}
     {# 4: Correspondent #}
     {# 5: Tags #}
+    {# 6: Document edit url #}
     <div class="box">
       <div class="result">
-        <div class="header">
+        <div class="header" onclick="location.href='{{ result.6 }}';" style="cursor: pointer;">
           <div class="checkbox">{{ result.0 }}</div>
           <div class="info">
             {{ result.4 }}<br />

--- a/src/documents/templatetags/hacks.py
+++ b/src/documents/templatetags/hacks.py
@@ -1,3 +1,5 @@
+import re
+
 from django.contrib.admin.templatetags.admin_list import (
     result_headers,
     result_hidden_fields,
@@ -5,6 +7,8 @@ from django.contrib.admin.templatetags.admin_list import (
 )
 from django.template import Library
 
+
+EXTRACT_URL = re.compile(r'href="(.*?)"')
 
 register = Library()
 
@@ -25,4 +29,15 @@ def result_list(cl):
             'result_hidden_fields': list(result_hidden_fields(cl)),
             'result_headers': headers,
             'num_sorted_fields': num_sorted_fields,
-            'results': list(results(cl))}
+            'results': map(add_doc_edit_url, results(cl))}
+
+
+def add_doc_edit_url(result):
+    """
+    Make the document edit URL accessible to the view as a separate item
+    """
+    title = result[1]
+    match = re.search(EXTRACT_URL, title)
+    edit_doc_url = match[1]
+    result.append(edit_doc_url)
+    return result


### PR DESCRIPTION
Increase the link area to include the whole visual header.

Fixes #335 

This is not an ideal solution because it 
1. requires Javascript
2. doesn't endow the header with link semantics, so, for example, the browser won't show a link preview on mouseover.

Maybe someone well-versed in CSS can (later) figure out a better approach.

Edit:
I've just added `WIP` to the title as I noticed that the `onclick` handler is erroneously triggered when the checkbox is clicked.
Is there a web dev out there who can help me finish this PR? :disappointed_relieved: :wink:
