### PR TITLE
fix bug where docker-entrypoint.sh exits w/o notice

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -46,11 +46,10 @@ migrations() {
     # A simple lock file in case other containers use this startup
     LOCKFILE="/usr/src/paperless/data/db.sqlite3.migration"
 
-    set -o noclobber
     # check for and create lock file in one command 
-    (> ${LOCKFILE}) &> /dev/null
-    if [ $? -eq 0 ]
+    if (set -o noclobber; echo "$$" > "${LOCKFILE}") 2> /dev/null
     then
+        trap 'rm -f "${LOCKFILE}"; exit $?' INT TERM EXIT
         sudo -HEu paperless "/usr/src/paperless/src/manage.py" "migrate"
         rm ${LOCKFILE}
     fi


### PR DESCRIPTION
This commit fixes a nasty bug, where the docker-entrypoint.sh silently
exits without any error message. The test for a lock file can fail and
due to the `set -e` at the beginning of the file the bash script exists
without starting the paperless application.
It is fixed by moving the check for the existence of the lock file into
the if statement, where the `set -e` does not trigger an exit in case
the statement fails (see https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html in the section for parameter `-e`).

Additionally this commit enables the script to trap exit signals and in
that case deletes the lock file.