### PR TITLE
[WIP] Docker use gunicorn deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN apk update --no-cache && apk add python3 gnupg libmagic libpq bash shadow cu
 
 WORKDIR /usr/src/paperless/src
 # Mount volumes and set Entrypoint
-VOLUME ["/usr/src/paperless/data", "/usr/src/paperless/media", "/consume", "/export"]
+VOLUME ["/usr/src/paperless/data", "/usr/src/paperless/media", "/consume", "/export", "/usr/src/paperless/static"]
 ENTRYPOINT ["/sbin/docker-entrypoint.sh"]
 CMD ["--help"]
 

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -59,6 +59,7 @@ initialize() {
     map_uidgid
     set_permissions
     migrations
+    sudo -HEu paperless "/usr/src/paperless/src/manage.py" "collectstatic" "--clear" "--no-input"
 }
 
 install_languages() {
@@ -97,6 +98,11 @@ if [[ "$1" != "/"* ]]; then
     # Install additional languages if specified
     if [ ! -z "$PAPERLESS_OCR_LANGUAGES"  ]; then
         install_languages "$PAPERLESS_OCR_LANGUAGES"
+    fi
+
+    if [ "$@" = "gunicorn" ]; then
+      cd /usr/src/paperless/src/ && \
+      exec sudo -HEu paperless GUNICORN_CMD_ARGS="--bind=0.0.0.0:8000 --access-logfile=- --log-file=-" /usr/bin/gunicorn paperless.wsgi
     fi
 
     exec sudo -HEu paperless "/usr/src/paperless/src/manage.py" "$@"

--- a/src/paperless/urls.py
+++ b/src/paperless/urls.py
@@ -36,7 +36,7 @@ urlpatterns = [
 
     # File downloads
     url(
-        r"^fetch/(?P<kind>doc|thumb)/(?P<pk>\d+)$",
+        r"fetch/(?P<kind>doc|thumb)/(?P<pk>\d+)$",
         FetchView.as_view(),
         name="fetch"
     ),


### PR DESCRIPTION
The docker container uses gunicorn to launch the application. Static files need to be served separately.

So i am using paperless in a subpath of my domain now. Maybe #253 is an related issue?

This is the snippet of my nginx.conf:

```
        location /pl/static/ {
            alias /data/paperless/static/;
        }
        location /pl {
            proxy_set_header Host $host;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_pass http://127.0.0.1:8000;
        }
```

This is my create call for the webserver docker:

`docker create --name $CONTAINERNAME -p 8000:8000 -v /data/paperless/data:/usr/src/paperless/data -v /data/paperless/media:/usr/src/paperless/media -v /data/paperless/static:/usr/src/paperless/static -e PAPERLESS_PASSPHRASE=supersecret -e PAPERLESS_FORCE_SCRIPT_NAME=/pl -e PAPERLESS_STATIC_URL=/pl/static/ strubbl_paperless gunicorn`


I am not familiar with and not using docker-compose and therefore did not update any related files. Maybe someone can help here?