### PR TITLE
Fix incompatibility with Python versions < 3.6

### DIFF
--- a/src/documents/templatetags/hacks.py
+++ b/src/documents/templatetags/hacks.py
@@ -38,6 +38,6 @@ def add_doc_edit_url(result):
     """
     title = result[1]
     match = re.search(EXTRACT_URL, title)
-    edit_doc_url = match[1]
+    edit_doc_url = match.group(1)
     result.append(edit_doc_url)
     return result


### PR DESCRIPTION
Direct index access to a match was only added in 3.6.

Fixes #359