### PR TITLE
add search field on admin start page and module start page

### DIFF
--- a/src/documents/templates/admin/index.html
+++ b/src/documents/templates/admin/index.html
@@ -4,6 +4,24 @@
 {% load i18n static %}
 
 
+{# This block adds a search form on the admin start page and on the module start page so that #}
+{# the user can quickly search for documents #}
+{% block pretitle %}
+<div>
+    <h3>{% trans 'Search documents' %}</h3>
+
+    <div id="toolbar"><form id="changelist-search" method="get" action="{% url 'admin:documents_document_changelist' %}">
+            <div><!-- DIV needed for valid HTML -->
+                <label for="searchbar"><img src="{% static "admin/img/search.svg" %}" alt="Search"></label>
+                <input type="text" size="40" name="q" value="" id="searchbar" autofocus="">
+                <input type="submit" value="{% trans 'Search' %}">
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}
+
+
 {# This whole block is here just to override the `get_admin_log` line so #}
 {# that the log entries aren't limited to the current user #}
 {% block sidebar %}


### PR DESCRIPTION
99% of the time when I open the Paperless web interface I want to quickly search for a document using the search field in the documents list.
Currently this requires users to open the documents list, wait for their connection to transfer a lot of not relevant thumbnail images, then type in the search term and then hit search.

To make Paperless a bit more mobile-friendly and to improve the workflow a bit for this common scenario, I've added a search box to the start page. This search box is referencing the default document_changelist search functionality (checkout the source code).
I've tried to implement this change with the minimal modifications needed, only by adding a form in the HTML.

This is how it looks on the desktop:
<img width="672" alt="image" src="https://user-images.githubusercontent.com/2536303/42273807-97ff92a0-7f8a-11e8-8567-b86dc5b8f84a.png">

This is how it looks on mobile:
<img width="235" alt="image" src="https://user-images.githubusercontent.com/2536303/42273953-360bef34-7f8b-11e8-8b1b-1294bb1f0074.png">

After long consideration I've recently switched from (the also great) Mayan EDMS to Paperless and am fully delighted - thanks for this great piece of software! I can now run my DMS on a much smaller and more resource-saving machine and modifications are a breeze.
