### PR TITLE
add document count column for tags and correspondents

### DIFF
--- a/src/documents/admin.py
+++ b/src/documents/admin.py
@@ -105,16 +105,22 @@ class CommonAdmin(admin.ModelAdmin):
 
 class CorrespondentAdmin(CommonAdmin):
 
-    list_display = ("name", "match", "matching_algorithm")
+    list_display = ("name", "match", "matching_algorithm", "document_count")
     list_filter = ("matching_algorithm",)
     list_editable = ("match", "matching_algorithm")
+
+    def document_count(self, obj):
+        return obj.documents.count()
 
 
 class TagAdmin(CommonAdmin):
 
-    list_display = ("name", "colour", "match", "matching_algorithm")
+    list_display = ("name", "colour", "match", "matching_algorithm", "document_count")
     list_filter = ("colour", "matching_algorithm")
     list_editable = ("colour", "match", "matching_algorithm")
+
+    def document_count(self, obj):
+        return obj.documents.count()
 
 
 class DocumentAdmin(CommonAdmin):

--- a/src/documents/admin.py
+++ b/src/documents/admin.py
@@ -115,7 +115,8 @@ class CorrespondentAdmin(CommonAdmin):
 
 class TagAdmin(CommonAdmin):
 
-    list_display = ("name", "colour", "match", "matching_algorithm", "document_count")
+    list_display = ("name", "colour", "match", "matching_algorithm",
+                    "document_count")
     list_filter = ("colour", "matching_algorithm")
     list_editable = ("colour", "match", "matching_algorithm")
 


### PR DESCRIPTION
This adds a column to the "Tags" and "Correspondents" view.
It's useful for finding unused tags or correspondents.

Screenshot:
![image](https://user-images.githubusercontent.com/2536303/42319935-d874089c-8053-11e8-906e-63df9e564b01.png)
