### PR TITLE
optimize Dockerfile for caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,8 @@ LABEL maintainer="The Paperless Project https://github.com/danielquinn/paperless
       contributors="Guy Addadi <addadi@gmail.com>, Pit Kleyersburg <pitkley@googlemail.com>, \
         Sven Fischer <git-dev@linux4tw.de>"
 
-# Copy application
+# Copy requirements file and init script
 COPY requirements.txt /usr/src/paperless/
-COPY src/ /usr/src/paperless/src/
-COPY data/ /usr/src/paperless/data/
-COPY media/ /usr/src/paperless/media/
 COPY scripts/docker-entrypoint.sh /sbin/docker-entrypoint.sh
 
 # Set export and consumption directories
@@ -43,4 +40,9 @@ WORKDIR /usr/src/paperless/src
 VOLUME ["/usr/src/paperless/data", "/usr/src/paperless/media", "/consume", "/export"]
 ENTRYPOINT ["/sbin/docker-entrypoint.sh"]
 CMD ["--help"]
+
+# Copy application
+COPY src/ /usr/src/paperless/src/
+COPY data/ /usr/src/paperless/data/
+COPY media/ /usr/src/paperless/media/
 


### PR DESCRIPTION
I've reordered the Dockerfile a bit. This helps users who change stuff in the Django-app and want to rebuild it using ```docker-compose up -d --build```.
Docker is then noticing that e.g. the requirements.txt didn't change and that no package reinstallation is necessary. It'll quickly jump to the step where the application files are added, speeding up the development process for Docker users.

See the screenshot of a cached build for clarification:
<img width="1399" alt="image" src="https://user-images.githubusercontent.com/2536303/42320071-4d33fa16-8054-11e8-87d7-58c1240a6966.png">
