### PR TITLE
Stop tests from writing to the source tree

### DIFF
--- a/src/paperless_tesseract/tests/test_date.py
+++ b/src/paperless_tesseract/tests/test_date.py
@@ -33,7 +33,7 @@ class TestDate(TestCase):
 
     @mock.patch(
         "paperless_tesseract.parsers.RasterisedDocumentParser.SCRATCH",
-        SAMPLE_FILES
+        SCRATCH
     )
     def test_date_format_2(self):
         input_file = os.path.join(self.SAMPLE_FILES, "")
@@ -43,7 +43,7 @@ class TestDate(TestCase):
 
     @mock.patch(
         "paperless_tesseract.parsers.RasterisedDocumentParser.SCRATCH",
-        SAMPLE_FILES
+        SCRATCH
     )
     def test_date_format_3(self):
         input_file = os.path.join(self.SAMPLE_FILES, "")
@@ -53,7 +53,7 @@ class TestDate(TestCase):
 
     @mock.patch(
         "paperless_tesseract.parsers.RasterisedDocumentParser.SCRATCH",
-        SAMPLE_FILES
+        SCRATCH
     )
     def test_date_format_4(self):
         input_file = os.path.join(self.SAMPLE_FILES, "")
@@ -66,7 +66,7 @@ class TestDate(TestCase):
 
     @mock.patch(
         "paperless_tesseract.parsers.RasterisedDocumentParser.SCRATCH",
-        SAMPLE_FILES
+        SCRATCH
     )
     def test_date_format_5(self):
         input_file = os.path.join(self.SAMPLE_FILES, "")
@@ -80,7 +80,7 @@ class TestDate(TestCase):
 
     @mock.patch(
         "paperless_tesseract.parsers.RasterisedDocumentParser.SCRATCH",
-        SAMPLE_FILES
+        SCRATCH
     )
     def test_date_format_6(self):
         input_file = os.path.join(self.SAMPLE_FILES, "")
@@ -100,7 +100,7 @@ class TestDate(TestCase):
 
     @mock.patch(
         "paperless_tesseract.parsers.RasterisedDocumentParser.SCRATCH",
-        SAMPLE_FILES
+        SCRATCH
     )
     def test_date_format_7(self):
         input_file = os.path.join(self.SAMPLE_FILES, "")
@@ -117,7 +117,7 @@ class TestDate(TestCase):
 
     @mock.patch(
         "paperless_tesseract.parsers.RasterisedDocumentParser.SCRATCH",
-        SAMPLE_FILES
+        SCRATCH
     )
     def test_date_format_8(self):
         input_file = os.path.join(self.SAMPLE_FILES, "")
@@ -138,7 +138,7 @@ class TestDate(TestCase):
 
     @mock.patch(
         "paperless_tesseract.parsers.RasterisedDocumentParser.SCRATCH",
-        SAMPLE_FILES
+        SCRATCH
     )
     def test_date_format_9(self):
         input_file = os.path.join(self.SAMPLE_FILES, "")
@@ -153,7 +153,7 @@ class TestDate(TestCase):
 
     @mock.patch(
         "paperless_tesseract.parsers.RasterisedDocumentParser.SCRATCH",
-        SAMPLE_FILES
+        SCRATCH
     )
     def test_get_text_1_pdf(self):
         input_file = os.path.join(self.SAMPLE_FILES, "tests_date_1.pdf")
@@ -359,7 +359,7 @@ class TestDate(TestCase):
 
     @mock.patch(
         "paperless_tesseract.parsers.RasterisedDocumentParser.SCRATCH",
-        SAMPLE_FILES
+        SCRATCH
     )
     def test_get_text_8_pdf(self):
         input_file = os.path.join(self.SAMPLE_FILES, "tests_date_8.pdf")
@@ -373,7 +373,7 @@ class TestDate(TestCase):
 
     @mock.patch(
         "paperless_tesseract.parsers.RasterisedDocumentParser.SCRATCH",
-        SAMPLE_FILES
+        SCRATCH
     )
     def test_get_text_9_pdf(self):
         input_file = os.path.join(self.SAMPLE_FILES, "tests_date_9.pdf")


### PR DESCRIPTION
While packaging paperless for [nixpkgs](https://github.com/NixOS/nixpkgs) I discovered that the tests write to the project source tree, which makes my package build fail.
Although I can work around this in the packaging process, I think it's best when tests treat the project source as immutable.

The offending tests are in `test_date.py` where a source dir is [used as a scratch dir](https://github.com/danielquinn/paperless/blob/master/src/paperless_tesseract/tests/test_date.py#L36) for `RasterisedDocumentParser`.
Other tests in the same file use a [scratch dir in /tmp](https://github.com/danielquinn/paperless/blob/master/src/paperless_tesseract/tests/test_date.py#L16) that gets removed via `tearDown` after each test.
So on first look, it may seem the source scratch dir has the purpose of retaining parser temp files for further inspection after a failed test.

But actually, none of the offending tests produce any temp files, only empty parser temp dirs.
(These empty dirs in `src/paperless_tesseract/tests/samples` don't show up in git's staging view and thus go unnoticed. You probably have hundreds of them.)
So we can simply change these tests to use /tmp. That's what this PR does.
