### PR TITLE
Enable CORS for localhost

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ chardet==3.0.4
 coverage==4.5.1
 coveralls==1.3.0
 dateparser==0.7.0
+django-cors-headers=2.4.0
 django-crispy-forms==1.7.2
 django-extensions==2.0.7
 django-filter==1.1.0

--- a/src/documents/filters.py
+++ b/src/documents/filters.py
@@ -1,4 +1,4 @@
-from django_filters.rest_framework import CharFilter, FilterSet
+from django_filters.rest_framework import CharFilter, FilterSet, BooleanFilter
 
 from .models import Correspondent, Document, Tag
 
@@ -46,6 +46,7 @@ class DocumentFilterSet(FilterSet):
     correspondent__slug = CharFilter(name="correspondent__slug", **CHAR_KWARGS)
     tags__name = CharFilter(name="tags__name", **CHAR_KWARGS)
     tags__slug = CharFilter(name="tags__slug", **CHAR_KWARGS)
+    tags__empty = BooleanFilter(name='tags', lookup_expr='isnull', distinct=True)
 
     class Meta(object):
         model = Document

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -61,6 +61,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
 
+    "corsheaders",
     "django_extensions",
 
     "documents.apps.DocumentsConfig",
@@ -84,6 +85,7 @@ if os.getenv("PAPERLESS_INSTALLED_APPS"):
 MIDDLEWARE_CLASSES = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -91,6 +93,9 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
+
+# We allow CORS from localhosts
+CORS_ORIGIN_REGEX_WHITELIST = (r'^(https?:\/\/)?localhost(:[0-9]{4})?$', )
 
 # If auth is disabled, we just use our "bypass" authentication middleware
 if bool(os.getenv("PAPERLESS_DISABLE_LOGIN", "false").lower() in ("yes", "y", "1", "t", "true")):


### PR DESCRIPTION
Hi,

I'm working on the new (minimalistic for now) frontend. As I don't want to change anything in the existing Django app (for now at least), I'm running it as a separate app that consumes the Django API.

To make it a replacement for current UI, I needed to do some tiny changes:

- enable CORS for localhost calls
- add Filter to allow API calls that can select Documents without any tag

I don't foresee any issues with the above, but if you think it's not a good idea, let me know!