### PR TITLE
Fix document checks with PostgreSQL and MySQL backends.

### DIFF
--- a/src/documents/checks.py
+++ b/src/documents/checks.py
@@ -2,7 +2,7 @@ import textwrap
 
 from django.conf import settings
 from django.core.checks import Error, register
-from django.db.utils import OperationalError
+from django.db.utils import OperationalError, ProgrammingError
 
 
 @register()
@@ -14,7 +14,7 @@ def changed_password_check(app_configs, **kwargs):
     try:
         encrypted_doc = Document.objects.filter(
             storage_type=Document.STORAGE_TYPE_GPG).first()
-    except OperationalError:
+    except (OperationalError, ProgrammingError):
         return []  # No documents table yet
 
     if encrypted_doc:


### PR DESCRIPTION
When running PostgreSQL or MariaDB/MySQL backends, almost all django management commands fail as long as the database is not yet populated. 

The reason seems to be that for those backends a ProgrammingError is raised in case a table does not exist. This error is, however, not properly caught in documents/checks.py. 

This patch fixes the error handling in the check.