### PR TITLE
Bump required version for Pyocr to support the latest tesseract 4.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ pillow==5.2.0
 pluggy==0.7.1; python_version != '3.1.*'
 py==1.6.0; python_version != '3.1.*'
 pycodestyle==2.4.0
-pyocr==0.5.2
+pyocr==0.5.3
 pytest-cov==2.5.1
 pytest-django==3.4.2
 pytest-env==0.6.2


### PR DESCRIPTION
This recently changed in the official tesseract engine [0]. `-psm` is
not allowed as an option anymore and `--psm` has to be used instead. The
latest pyocr enables support for this [1].

Thanks!

[0] tesseract-ocr/tesseract@ee201e1
[1] https://gitlab.gnome.org/World/OpenPaperwork/pyocr/commit/5abd0a566a0518bea00cb4247c16e67d0d3c2d65