### PR TITLE
Speed up thumbnail generation for PDFs

### DIFF
--- a/src/paperless_tesseract/parsers.py
+++ b/src/paperless_tesseract/parsers.py
@@ -50,10 +50,11 @@ class RasterisedDocumentParser(DocumentParser):
             self.CONVERT,
             "-scale", "500x5000",
             "-alpha", "remove",
-            self.document_path, os.path.join(self.tempdir, "convert-%04d.png")
+            "{}[0]".format(self.document_path),
+            os.path.join(self.tempdir, "convert.png")
         )
 
-        return os.path.join(self.tempdir, "convert-0000.png")
+        return os.path.join(self.tempdir, "convert.png")
 
     def _is_ocred(self):
 


### PR DESCRIPTION
Since we only use the first page of the PDF for thumbnail generation, the current method of converting the entire pdf to a series of .png images is wasteful, and can bog down the consumer if dealing with a very long (page-wise) PDF.

This PR uses the `convert` bracket syntax to load only the first page, and get the thumbnail from that instead of doing all the pages.