### PR TITLE
Add configurable option to display documents in browser instead of download

### DIFF
--- a/paperless.conf.example
+++ b/paperless.conf.example
@@ -117,6 +117,10 @@ PAPERLESS_EMAIL_SECRET=""
 # http://paperless.readthedocs.org/en/latest/consumption.html#hooking-into-the-consumption-process
 #PAPERLESS_POST_CONSUME_SCRIPT="/path/to/an/arbitrary/script.sh"
 
+# By default, when clicking on a document within the web interface, the
+# browser will prompt the user to save the document to disk. By uncommenting
+# the below, the document will instead be opened in the browser, if possible.
+#PAPERLESS_INLINE_DOC="true"
 
 #
 # The following values use sensible defaults for modern systems, but if you're

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -1,6 +1,8 @@
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.views.generic import DetailView, FormView, TemplateView
 from django_filters.rest_framework import DjangoFilterBackend
+from django.conf import settings
+
 from paperless.db import GnuPG
 from paperless.mixins import SessionOrBasicAuthMixin
 from paperless.views import StandardPagination
@@ -60,8 +62,12 @@ class FetchView(SessionOrBasicAuthMixin, DetailView):
             self._get_raw_data(self.object.source_file),
             content_type=content_types[self.object.file_type]
         )
-        response["Content-Disposition"] = 'attachment; filename="{}"'.format(
-            self.object.file_name)
+
+        print("OPEN_DOCUMENT", settings.INLINE_DOC)
+        DISPOSITION = 'inline' if settings.INLINE_DOC else 'attachment'
+
+        response["Content-Disposition"] = '{}; filename="{}"'.format(
+            DISPOSITION, self.object.file_name)
 
         return response
 

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -63,7 +63,6 @@ class FetchView(SessionOrBasicAuthMixin, DetailView):
             content_type=content_types[self.object.file_type]
         )
 
-        print("OPEN_DOCUMENT", settings.INLINE_DOC)
         DISPOSITION = 'inline' if settings.INLINE_DOC else 'attachment'
 
         response["Content-Disposition"] = '{}; filename="{}"'.format(

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -270,6 +270,9 @@ PASSPHRASE = os.getenv("PAPERLESS_PASSPHRASE")
 PRE_CONSUME_SCRIPT = os.getenv("PAPERLESS_PRE_CONSUME_SCRIPT")
 POST_CONSUME_SCRIPT = os.getenv("PAPERLESS_POST_CONSUME_SCRIPT")
 
+# Whether to display a selected document inline, or download it as attachment:
+INLINE_DOC = os.getenv("PAPERLESS_INLINE_DOC")
+
 # The number of items on each page in the web UI.  This value must be a
 # positive integer, but if you don't define one in paperless.conf, a default of
 # 100 will be used.


### PR DESCRIPTION
Adds parsing for a settings variable named `PAPERLESS_INLINE_DOC` that will enable configuration of the server behavior when loading a document. By default, the existing behavior of downloading the document (and presenting the user with a "Save as..." dialogue) is preserved. By defining the `PAPERLESS_INLINE_DOC` setting, the document will instead be rendered in the browser window, if possible (works for PDF and txt documents).