### PR TITLE
Added a bunch of new features.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,5 @@ docker-compose.env
 scripts/import-for-development
 scripts/nuke
 
+# Static files collected by the collectstatic command
+static/

--- a/paperless.conf.example
+++ b/paperless.conf.example
@@ -59,6 +59,11 @@ PAPERLESS_EMAIL_SECRET=""
 ####                              Security                                 ####
 ###############################################################################
 
+# Controls whether django's debug mode is enabled. Disable this on production
+# systems. Debug mode is enabled by default.
+PAPERLESS_DEBUG="false"
+
+
 # Paperless can be instructed to attempt to encrypt your PDF files with GPG
 # using the PAPERLESS_PASSPHRASE specified below.  If however you're not
 # concerned about encrypting these files (for example if you have disk
@@ -203,3 +208,8 @@ PAPERLESS_EMAIL_SECRET=""
 # positive integer, but if you don't define one in paperless.conf, a default of
 # 100 will be used.
 #PAPERLESS_LIST_PER_PAGE=100
+
+
+# The number of years for which a correspondent will be included in the recent
+# correspondents filter.
+#PAPERLESS_RECENT_CORRESPONDENT_YEARS=1

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ idna==2.7
 inotify-simple==1.1.8
 langdetect==1.0.7
 more-itertools==4.3.0
+numpy==1.15.1
 pdftotext==2.1.0
 pillow==5.2.0
 pluggy==0.7.1; python_version != '3.1.*'
@@ -45,6 +46,8 @@ pytz==2018.5
 regex==2018.8.29
 requests==2.19.1
 six==1.11.0
+scikit-learn==0.19.2
+scipy==1.1.0
 termcolor==1.1.0
 text-unidecode==1.2
 tzlocal==1.5.1

--- a/src/documents/actions.py
+++ b/src/documents/actions.py
@@ -1,0 +1,108 @@
+from django.contrib import messages
+from django.contrib.admin import helpers
+from django.contrib.admin.utils import model_ngettext
+from django.core.exceptions import PermissionDenied
+from django.template.response import TemplateResponse
+
+from documents.models import Tag, Correspondent
+
+
+def select_action(modeladmin, request, queryset, title, action, modelclass, success_message="", document_action=None, queryset_action=None):
+    opts = modeladmin.model._meta
+    app_label = opts.app_label
+
+    if not modeladmin.has_change_permission(request):
+        raise PermissionDenied
+
+    if request.POST.get('post'):
+        n = queryset.count()
+        selected_object = modelclass.objects.get(id=request.POST.get('obj_id'))
+        if n:
+            for document in queryset:
+                if document_action:
+                    document_action(document, selected_object)
+                document_display = str(document)
+                modeladmin.log_change(request, document, document_display)
+            if queryset_action:
+                queryset_action(queryset, selected_object)
+
+            modeladmin.message_user(request, success_message % {
+                "selected_object": selected_object.name, "count": n, "items": model_ngettext(modeladmin.opts, n)
+            }, messages.SUCCESS)
+
+        # Return None to display the change list page again.
+        return None
+
+    context = dict(
+        modeladmin.admin_site.each_context(request),
+        title=title,
+        queryset=queryset,
+        opts=opts,
+        action_checkbox_name=helpers.ACTION_CHECKBOX_NAME,
+        media=modeladmin.media,
+        action=action,
+        objects=modelclass.objects.all(),
+        itemname=model_ngettext(modelclass, 1)
+    )
+
+    request.current_app = modeladmin.admin_site.name
+
+    return TemplateResponse(request, "admin/%s/%s/select_object.html" % (app_label, opts.model_name), context)
+
+
+def simple_action(modeladmin, request, queryset, success_message="", document_action=None, queryset_action=None):
+    if not modeladmin.has_change_permission(request):
+        raise PermissionDenied
+
+    n = queryset.count()
+    if n:
+        for document in queryset:
+            if document_action:
+                document_action(document)
+            document_display = str(document)
+            modeladmin.log_change(request, document, document_display)
+        if queryset_action:
+            queryset_action(queryset)
+        modeladmin.message_user(request, success_message % {
+            "count": n, "items": model_ngettext(modeladmin.opts, n)
+        }, messages.SUCCESS)
+
+    # Return None to display the change list page again.
+    return None
+
+
+def add_tag_to_selected(modeladmin, request, queryset):
+    return select_action(modeladmin=modeladmin, request=request, queryset=queryset,
+                         title="Add tag to multiple documents",
+                         action="add_tag_to_selected",
+                         modelclass=Tag,
+                         success_message="Successfully added tag %(selected_object)s to %(count)d %(items)s.",
+                         document_action=lambda doc, tag: doc.tags.add(tag))
+add_tag_to_selected.short_description = "Add tag to selected documents"
+
+
+def remove_tag_from_selected(modeladmin, request, queryset):
+    return select_action(modeladmin=modeladmin, request=request, queryset=queryset,
+                         title="Remove tag from multiple documents",
+                         action="remove_tag_from_selected",
+                         modelclass=Tag,
+                         success_message="Successfully removed tag %(selected_object)s from %(count)d %(items)s.",
+                         document_action=lambda doc, tag: doc.tags.remove(tag))
+remove_tag_from_selected.short_description = "Remove tag from selected documents"
+
+
+def set_correspondent_on_selected(modeladmin, request, queryset):
+    return select_action(modeladmin=modeladmin, request=request, queryset=queryset,
+                         title="Set correspondent on multiple documents",
+                         action="set_correspondent_on_selected",
+                         modelclass=Correspondent,
+                         success_message="Successfully set correspondent %(selected_object)s on %(count)d %(items)s.",
+                         queryset_action=lambda qs, correspondent: qs.update(correspondent=correspondent))
+set_correspondent_on_selected.short_description = "Set correspondent on selected documents"
+
+
+def remove_correspondent_from_selected(modeladmin, request, queryset):
+    return simple_action(modeladmin=modeladmin, request=request, queryset=queryset,
+                         success_message="Successfully removed correspondent from %(count)d %(items)s.",
+                         queryset_action=lambda qs: qs.update(correspondent=None))
+remove_correspondent_from_selected.short_description = "Remove correspondent from selected documents"

--- a/src/documents/templates/admin/documents/document/change_form.html
+++ b/src/documents/templates/admin/documents/document/change_form.html
@@ -1,5 +1,21 @@
 {% extends 'admin/change_form.html' %}
 
+{% block content %}
+
+{{ block.super }}
+
+{% if next_object %}
+	<script type="text/javascript">//<![CDATA[
+		(function($){
+			$('<input type="submit" value="Save and edit next" name="_saveandeditnext" />')
+			.prependTo('div.submit-row');
+			$('<input type="hidden" value="{{next_object}}" name="_next_object" />')
+			.prependTo('div.submit-row');
+		})(django.jQuery);
+	//]]></script>
+{% endif %}
+
+{% endblock content %}
 
 {% block footer %}
 

--- a/src/documents/templates/admin/documents/document/select_object.html
+++ b/src/documents/templates/admin/documents/document/select_object.html
@@ -1,0 +1,46 @@
+{% extends "admin/base_site.html" %}
+{% load i18n l10n admin_urls static %}
+{% load staticfiles %}
+
+{% block extrahead %}
+{{ block.super }}
+{{ media }}
+<script type="text/javascript" src="{% static 'admin/js/cancel.js' %}"></script>
+
+{% endblock %}
+
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} delete-confirmation delete-selected-confirmation{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+    &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+    &rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+    &rsaquo; {{title}}
+</div>
+{% endblock %}
+
+{% block content %}
+<p>Please select the {{itemname}}.</p>
+<form method="post">{% csrf_token %}
+    <div>
+        {% for obj in queryset %}
+        <input type="hidden" name="{{ action_checkbox_name }}" value="{{ obj.pk|unlocalize }}"/>
+        {% endfor %}
+        <p>
+            <select name="obj_id">
+                {% for obj in objects %}
+                <option value="{{obj.id}}">{{obj.name}}</option>
+                {% endfor %}
+            </select>
+        </p>
+
+        <input type="hidden" name="action" value="{{action}}"/>
+        <input type="hidden" name="post" value="yes"/>
+        <p>
+            <input type="submit" value="{% trans "Confirm" %}" />
+            <a href="#" class="button cancel-link">{% trans "Go back" %}</a>
+        </p>
+    </div>
+</form>
+{% endblock %}

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -22,12 +22,12 @@ elif os.path.exists("/usr/local/etc/paperless.conf"):
     load_dotenv("/usr/local/etc/paperless.conf")
 
 
-def __get_boolean(key):
+def __get_boolean(key, default="NO"):
     """
     Return a boolean value based on whatever the user has supplied in the
     environment based on whether the value "looks like" it's True or not.
     """
-    return bool(os.getenv(key, "NO").lower() in ("yes", "y", "1", "t", "true"))
+    return bool(os.getenv(key, default).lower() in ("yes", "y", "1", "t", "true"))
 
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -47,7 +47,7 @@ SECRET_KEY = os.getenv(
 
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = __get_boolean("PAPERLESS_DEBUG", "YES")
 
 LOGIN_URL = "admin:login"
 
@@ -81,7 +81,7 @@ INSTALLED_APPS = [
 
     "rest_framework",
     "crispy_forms",
-    "django_filters",
+    "django_filters"
 
 ]
 
@@ -292,3 +292,9 @@ FY_END = os.getenv("PAPERLESS_FINANCIAL_YEAR_END")
 
 # Specify the default date order (for autodetected dates)
 DATE_ORDER = os.getenv("PAPERLESS_DATE_ORDER", "DMY")
+
+# Specify for how many years a correspondent is considered recent. Recent
+# correspondents will be shown in a separate "Recent correspondents" filter as
+# well. Set to 0 to disable this filter.
+PAPERLESS_RECENT_CORRESPONDENT_YEARS = int(os.getenv(
+    "PAPERLESS_RECENT_CORRESPONDENT_YEARS", 0))


### PR DESCRIPTION
I've made various modifications to paperless to fit it to my needs. Some of the changes I've made may be useful for other people as well, so I've opened a pull request. Most of these changes are non-intrusive and don't affect how paperless works,

- Debug mode is now configurable in the configuration file. This way, we don't have to edit versioned files to disable it on production systems.
- Recent correspondents filter (enable in configuration file)
- Document actions: Edit tags and correspondents on multiple documents at once (it's in the dropdown menu)
- Replaced month list filter with date drilldown
- Sortable document count columns on Tag and Correspondent admin
- Last correspondence column on Correspondent admin
- Save and edit next functionality for document editing

Some comments on the changes:

- Debug mode is still enabled by default. However, copying the example configuration file will disable it.
- The month list filter does not exist anymore. However, the date drilldown feels like a much better alternative.
- Save and edit next is now the **default** action on the document change form, meaning that hitting Enter in one of the editable fields will **not** return to the document list, but to the next document instead.

I've made more changes, which are either experimental, intrusive, or potentially unnecessary for other users. If you want these merged as well, please tell me.

- Inbox and Archive tags. These are special tags. Inbox tags get assigned to all new documents automatically. Documents tagged with Archive tags will never be modified automatically (i.e., by matching rules). The rationale behind Inbox is that one may want to verify the tags and correspondents on newly added documents and then remove these documents from the inbox by removing the inbox tag.
- Document types. (i.e., Invoice, Contract, Letter, Receipt, etc)
- Document viewers. On the document edit page, certain document types (pdf, jpg, png) will be displayed next to the document edit form. Editing metadata is much easier this way. Breaks the page layout on small screens.
- Archive Serial Number. I keep the physical copy of some important documents. This helps me to quickly find a document if needed.
- And here's the change I'm most exited about: I've replaced your matching algorithms with a mathematical model that learns matching patterns from already tagged documents. This model is used to tag newly added documents. Works reasonably well (far better than hand-crafted matching rules, from my experience) on my data (which is a collection of ~1000 documents with ~100 correspondents and ~10 tags). Highly experimental!

Cheers.