### PR TITLE
Hotfix for issue #416

### DIFF
--- a/src/documents/admin.py
+++ b/src/documents/admin.py
@@ -212,9 +212,9 @@ class DocumentAdmin(CommonAdmin):
             extra_context=extra_context
         )
 
-        if request.method == "GET":
-            cl = self.get_changelist_instance(request)
-            self.document_queue = [doc.id for doc in cl.queryset]
+        #if request.method == "GET":
+        #    cl = self.get_changelist_instance(request)
+        #    self.document_queue = [doc.id for doc in cl.queryset]
 
         return response
 


### PR DESCRIPTION
This comments out a part that was added in the last update and causes the webserver to stop serving files. It is just a temporary fix so that users that are affected by this issue can continue using paperless until the cause is fixed.

Issue #416 