### PR TITLE
Clarify forgiving ocr handling

### DIFF
--- a/paperless.conf.example
+++ b/paperless.conf.example
@@ -188,6 +188,11 @@ PAPERLESS_DEBUG="false"
 #PAPERLESS_CONSUMER_LOOP_TIME=10
 
 
+# By default Paperless stops consuming a document if no language can be detected.
+# Set to true to consume documents even if the language detection fails.
+#PAPERLESS_FORGIVING_OCR="false"
+
+
 ###############################################################################
 ####                            Interface                                  ####
 ###############################################################################

--- a/src/paperless_tesseract/parsers.py
+++ b/src/paperless_tesseract/parsers.py
@@ -153,7 +153,10 @@ class RasterisedDocumentParser(DocumentParser):
                 )
                 raw_text = self._assemble_ocr_sections(imgs, middle, raw_text)
                 return raw_text
-            raise OCRError("Language detection failed")
+            error_msg = ("Language detection failed. Set "
+                         "PAPERLESS_FORGIVING_OCR in config file to continue "
+                         "anyway.")
+            raise OCRError(error_msg)
 
         if ISO639[guessed_language] == self.DEFAULT_OCR_LANGUAGE:
             raw_text = self._assemble_ocr_sections(imgs, middle, raw_text)


### PR DESCRIPTION
Good day,

I have had a document fail to consume because no language could be detected. I had to look it up in the code as it wasn't clear to me what to do about it. With this pull request, we

- mention the `PAPERLESS_FORGIVING_OCR` option in the error message as a hint on how to continue with document consuming even in case of language detection errors
- add the `PAPERLESS_FORGIVING_OCR` option to the example config so that it is documented

Thanks!