### PR TITLE
requirements.txt: bring back Linux-only restriction for inotify-simple

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ filemagic==1.6
 fuzzywuzzy==0.15.0
 gunicorn==19.9.0
 idna==2.7
-inotify-simple==1.1.8
+inotify-simple==1.1.8; sys_platform == 'linux'
 langdetect==1.0.7
 more-itertools==4.3.0
 pdftotext==2.1.0


### PR DESCRIPTION
Fixes #418 

@danielquinn, the Linux restriction was lost in your (probably automatic) ["update dependencies" commit](https://github.com/danielquinn/paperless/commit/39ef81d398772587d5f42a39d5da224c6c2b5c21).