### PR TITLE
Update gunicorn commands

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -366,7 +366,7 @@ The gunicorn server can be started with the command:
 
 .. code-block:: shell
 
-    $ <path-to-paperless-virtual-environment>/bin/gunicorn <path-to-paperless>/src/paperless.wsgi -w 2
+    $ <path-to-paperless-virtual-environment>/bin/gunicorn --pythonpath=<path-to-paperless>/src paperless.wsgi -w 2
 
 
 .. _setup-permanent-standard-systemd:
@@ -423,7 +423,7 @@ after restarting your system:
     respawn limit 10 5
 
     script
-      exec <path to paperless virtual environment>/bin/gunicorn <path to parperless>/src/paperless.wsgi -w 2
+      exec <path to paperless virtual environment>/bin/gunicorn --pythonpath=<path to parperless>/src paperless.wsgi -w 2
     end script
 
    Note that you'll need to replace ``/srv/paperless/src/manage.py`` with the

--- a/scripts/paperless-webserver.service
+++ b/scripts/paperless-webserver.service
@@ -4,7 +4,7 @@ Description=Paperless webserver
 [Service]
 User=paperless
 Group=paperless
-ExecStart=/home/paperless/project/virtualenv/bin/gunicorn /home/paperless/project/src/paperless.wsgi -w 2
+ExecStart=/home/paperless/project/virtualenv/bin/gunicorn --pythonpath=/home/paperless/project/src paperless.wsgi -w 2
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I had previously been using Django's built-in server, but I just switched to nginx+gunicorn (much faster!)

On my system, the gunicorn command (and the service files) needed some modification to run because of a `ModuleNotFoundError`. The solution was found [here](https://stackoverflow.com/questions/47710428/gunicorn-no-module-named-path-to-my-django-project). I believe all the relevant files have been updated, if anyone wants to test them out.