### PR TITLE
Set consume directory for webserver too

### DIFF
--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -17,6 +17,9 @@ services:
         volumes:
             - data:/usr/src/paperless/data
             - media:/usr/src/paperless/media
+						# You have to adapt the local path you want the consumption
+            # directory to mount to by modifying the part before the ':'.
+						- ./consume:/consume
         env_file: docker-compose.env
         # The reason the line is here is so that the webserver that doesn't do
         # any text recognition and doesn't have to install unnecessary
@@ -36,8 +39,8 @@ services:
         volumes:
             - data:/usr/src/paperless/data
             - media:/usr/src/paperless/media
-            # You have to adapt the local path you want the consumption
-            # directory to mount to by modifying the part before the ':'.
+            # This should be set to the same value as the consume directory
+					  # in the webserver service above.
             - ./consume:/consume
             # Likewise, you can add a local path to mount a directory for
             # exporting. This is not strictly needed for paperless to


### PR DESCRIPTION
Fixes #289 

The HTTP POST endpoint saves the file in the consume directory.
This needs to be shared between the two services so that the file is actually consumed.