### PR TITLE
Reference PAPERLESS_OCR_ALWAYS in example config file.

### DIFF
--- a/paperless.conf.example
+++ b/paperless.conf.example
@@ -193,6 +193,11 @@ PAPERLESS_DEBUG="false"
 #PAPERLESS_FORGIVING_OCR="false"
 
 
+# By default Paperless does not OCR a document if the text can be retrieved from
+# the document directly. Set to true to always OCR documents.
+#PAPERLESS_OCR_ALWAYS="false"
+
+
 ###############################################################################
 ####                            Interface                                  ####
 ###############################################################################


### PR DESCRIPTION
This setting was introduced when support for retrieving the text layer
from documents was added. Having it in the example config makes it more
clear that it exists.