### PR TITLE
Exposing documents' "added" timestamp via Rest API.

### DIFF
--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -46,6 +46,7 @@ class DocumentSerializer(serializers.ModelSerializer):
             "checksum",
             "created",
             "modified",
+            "added",
             "file_name",
             "download_url",
             "thumbnail_url",

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -130,7 +130,7 @@ class DocumentViewSet(RetrieveModelMixin,
     filter_class = DocumentFilterSet
     search_fields = ("title", "correspondent__name", "content")
     ordering_fields = (
-        "id", "title", "correspondent__name", "created", "modified")
+        "id", "title", "correspondent__name", "created", "modified", "added")
 
 
 class LogViewSet(ReadOnlyModelViewSet):


### PR DESCRIPTION
I recognized that the Rest API doesn't expose the "added" timestamp of documents. This PR fixes that.
I hope it's ok to create a PR without opening an issue before.