### PR TITLE
Catch IMAP connection errors

### DIFF
--- a/src/documents/mail.py
+++ b/src/documents/mail.py
@@ -216,7 +216,11 @@ class MailFetcher(Loggable):
         return r
 
     def _connect(self):
-        self._connection = imaplib.IMAP4_SSL(self._host, self._port)
+        try:
+            self._connection = imaplib.IMAP4_SSL(self._host, self._port)
+        except OSError as e:
+            msg = "Problem connecting to {}: {}".format(self._host, e.strerror)
+            raise MailFetcherError(msg)
 
     def _login(self):
 


### PR DESCRIPTION
imaplib.IMAP4_SSL raises a socket.gaierror when something goes wrong with connecting
to PAPERLESS_CONSUME_MAIL_HOST. Later MailFetcherErrors are excepted, but socket.gaierror
are not, so instead raise a MailFetcherError. Because socket.gaierrors can have numerous
reasons (gaierror wraps EAI_* errors from getaddrinfo, so see man getaddrinfo EAI_*),
include the error description in the exception.

Fixes #474